### PR TITLE
fix(issue-52): use pull request github api url as source

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -560,7 +560,7 @@ exports.inferGitClient = inferGitClient;
 const inferGitApiUrl = (prUrl, apiVersion = "v4") => {
     const url = new URL(prUrl);
     const baseUrl = `${url.protocol}//${url.host}`;
-    if (baseUrl.includes(PUBLIC_GITHUB_URL)) {
+    if (baseUrl.includes(PUBLIC_GITHUB_URL) || baseUrl.includes(PUBLIC_GITHUB_API)) {
         return PUBLIC_GITHUB_API;
     }
     return `${baseUrl}/api/${apiVersion}`;

--- a/dist/gha/index.js
+++ b/dist/gha/index.js
@@ -534,7 +534,7 @@ exports.inferGitClient = inferGitClient;
 const inferGitApiUrl = (prUrl, apiVersion = "v4") => {
     const url = new URL(prUrl);
     const baseUrl = `${url.protocol}//${url.host}`;
-    if (baseUrl.includes(PUBLIC_GITHUB_URL)) {
+    if (baseUrl.includes(PUBLIC_GITHUB_URL) || baseUrl.includes(PUBLIC_GITHUB_API)) {
         return PUBLIC_GITHUB_API;
     }
     return `${baseUrl}/api/${apiVersion}`;

--- a/src/service/git/git-util.ts
+++ b/src/service/git/git-util.ts
@@ -31,7 +31,7 @@ export const inferGitApiUrl = (prUrl: string, apiVersion = "v4"): string => {
   const url = new URL(prUrl);
   const baseUrl = `${url.protocol}//${url.host}`;
   
-  if (baseUrl.includes(PUBLIC_GITHUB_URL)) {
+  if (baseUrl.includes(PUBLIC_GITHUB_URL) || baseUrl.includes(PUBLIC_GITHUB_API)) {
     return PUBLIC_GITHUB_API;
   }
 

--- a/test/service/git/git-util.test.ts
+++ b/test/service/git/git-util.test.ts
@@ -24,14 +24,22 @@ describe("check git utilities", () => {
   });
 
   test("check infer github client", ()=> {
-    expect(inferGitClient("https://github.com/superuser/backporting-example/-/merge_requests/4")).toStrictEqual(GitClientType.GITHUB);
+    expect(inferGitClient("https://github.com/superuser/backporting-example/pull/4")).toStrictEqual(GitClientType.GITHUB);
   });
 
   test("check infer gitlab client", ()=> {
     expect(inferGitClient("https://my.gitlab.awesome.com/superuser/backporting-example/-/merge_requests/4")).toStrictEqual(GitClientType.GITLAB);
   });
 
-  test("Not recognized git client type", ()=> {
+  test("not recognized git client type", ()=> {
     expect(() => inferGitClient("https://not.recognized/superuser/backporting-example/-/merge_requests/4")).toThrowError("Remote git service not recognized from pr url: https://not.recognized/superuser/backporting-example/-/merge_requests/4");
+  });
+
+  test("check infer github client using github api", ()=> {
+    expect(inferGitClient("https://api.github.com/repos/owner/repo/pulls/1")).toStrictEqual(GitClientType.GITHUB);
+  });
+
+  test("check infer github api from github api url", ()=> {
+    expect(inferGitApiUrl("https://api.github.com/repos/owner/repo/pulls/1")).toStrictEqual("https://api.github.com");
   });
 });

--- a/test/service/runner/cli-github-runner.test.ts
+++ b/test/service/runner/cli-github-runner.test.ts
@@ -5,6 +5,8 @@ import GitHubClient from "@bp/service/git/github/github-client";
 import CLIArgsParser from "@bp/service/args/cli/cli-args-parser";
 import { addProcessArgs, createTestFile, removeTestFile, resetProcessArgs } from "../../support/utils";
 import { mockGitHubClient } from "../../support/mock/git-client-mock-support";
+import GitClientFactory from "@bp/service/git/git-client-factory";
+import { GitClientType } from "@bp/service/git/git.types";
 
 const GITHUB_MERGED_PR_W_OVERRIDES_CONFIG_FILE_CONTENT_PATHNAME = "./cli-github-runner-pr-merged-with-overrides.json";
 const GITHUB_MERGED_PR_W_OVERRIDES_CONFIG_FILE_CONTENT = {
@@ -27,6 +29,7 @@ const GITHUB_MERGED_PR_W_OVERRIDES_CONFIG_FILE_CONTENT = {
 
 jest.mock("@bp/service/git/git-cli");
 jest.spyOn(GitHubClient.prototype, "createPullRequest");
+jest.spyOn(GitClientFactory, "getOrCreate");
 
 let parser: ArgsParser;
 let runner: Runner;
@@ -72,6 +75,9 @@ describe("cli runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
@@ -133,6 +139,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/folder";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -167,6 +176,9 @@ describe("cli runner", () => {
 
     const cwd = "/tmp/folder";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -194,6 +206,9 @@ describe("cli runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
@@ -236,6 +251,9 @@ describe("cli runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
@@ -288,6 +306,9 @@ describe("cli runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
@@ -343,6 +364,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -396,6 +420,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -441,6 +468,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -485,6 +515,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -525,6 +558,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, "my-auth-token", "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -551,6 +587,52 @@ describe("cli runner", () => {
         reviewers: [],
         assignees: ["user3", "user4"],
         labels: ["cli github cherry pick :cherries:", "original-label"],
+      }
+    );
+  });
+
+  // to check: https://github.com/kiegroup/git-backporting/issues/52
+  test("using github api url instead of html one", async () => {
+    addProcessArgs([
+      "-tb",
+      "target",
+      "-pr",
+      "https://api.github.com/repos/owner/reponame/pulls/2368"
+    ]);
+    
+    await runner.execute();
+
+    const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
+    expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
+
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    
+    expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
+
+    expect(GitCLIService.prototype.cherryPick).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+
+    expect(GitCLIService.prototype.push).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+
+    expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
+    expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
+        owner: "owner", 
+        repo: "reponame", 
+        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        base: "target", 
+        title: "[target] PR Title", 
+        body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
+        reviewers: ["gh-user", "that-s-a-user"],
+        assignees: [],
+        labels: [],
       }
     );
   });

--- a/test/service/runner/cli-gitlab-runner.test.ts
+++ b/test/service/runner/cli-gitlab-runner.test.ts
@@ -6,6 +6,8 @@ import CLIArgsParser from "@bp/service/args/cli/cli-args-parser";
 import { addProcessArgs, createTestFile, removeTestFile, resetProcessArgs } from "../../support/utils";
 import { getAxiosMocked } from "../../support/mock/git-client-mock-support";
 import { MERGED_SQUASHED_MR } from "../../support/mock/gitlab-data";
+import GitClientFactory from "@bp/service/git/git-client-factory";
+import { GitClientType } from "@bp/service/git/git.types";
 
 const GITLAB_MERGED_PR_COMPLEX_CONFIG_FILE_CONTENT_PATHNAME = "./cli-gitlab-runner-pr-merged-with-overrides.json";
 const GITLAB_MERGED_PR_COMPLEX_CONFIG_FILE_CONTENT = {
@@ -41,6 +43,7 @@ jest.mock("axios", () => {
 
 jest.mock("@bp/service/git/git-cli");
 jest.spyOn(GitLabClient.prototype, "createPullRequest");
+jest.spyOn(GitClientFactory, "getOrCreate");
 
 
 let parser: ArgsParser;
@@ -86,6 +89,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
@@ -117,6 +123,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/folder";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
@@ -147,6 +156,9 @@ describe("cli runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
@@ -200,6 +212,9 @@ describe("cli runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
@@ -257,6 +272,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
@@ -310,6 +328,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
@@ -354,6 +375,9 @@ describe("cli runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
@@ -400,6 +424,9 @@ describe("cli runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
@@ -440,6 +467,9 @@ describe("cli runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, "my-token", "https://my.gitlab.host.com/api/v4");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "prod");

--- a/test/service/runner/gha-github-runner.test.ts
+++ b/test/service/runner/gha-github-runner.test.ts
@@ -5,6 +5,8 @@ import GitHubClient from "@bp/service/git/github/github-client";
 import GHAArgsParser from "@bp/service/args/gha/gha-args-parser";
 import { createTestFile, removeTestFile, spyGetInput } from "../../support/utils";
 import { mockGitHubClient } from "../../support/mock/git-client-mock-support";
+import GitClientFactory from "@bp/service/git/git-client-factory";
+import { GitClientType } from "@bp/service/git/git.types";
 
 const GITHUB_MERGED_PR_W_OVERRIDES_CONFIG_FILE_CONTENT_PATHNAME = "./gha-github-runner-pr-merged-with-overrides.json";
 const GITHUB_MERGED_PR_W_OVERRIDES_CONFIG_FILE_CONTENT = {
@@ -28,6 +30,7 @@ const GITHUB_MERGED_PR_W_OVERRIDES_CONFIG_FILE_CONTENT = {
 
 jest.mock("@bp/service/git/git-cli");
 jest.spyOn(GitHubClient.prototype, "createPullRequest");
+jest.spyOn(GitClientFactory, "getOrCreate");
 
 let parser: ArgsParser;
 let runner: Runner;
@@ -68,6 +71,9 @@ describe("gha runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -93,6 +99,9 @@ describe("gha runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
@@ -143,6 +152,9 @@ describe("gha runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -188,6 +200,9 @@ describe("gha runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
@@ -236,6 +251,9 @@ describe("gha runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -277,6 +295,9 @@ describe("gha runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
@@ -320,6 +341,9 @@ describe("gha runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -359,6 +383,9 @@ describe("gha runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, "my-auth-token", "https://api.github.com");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
@@ -388,4 +415,49 @@ describe("gha runner", () => {
       }
     );
   });
+
+  // to check: https://github.com/kiegroup/git-backporting/issues/52
+  test("using github api url instead of html one", async () => {
+    spyGetInput({
+      "target-branch": "target",
+      "pull-request": "https://api.github.com/repos/owner/reponame/pulls/2368"
+    });
+
+    await runner.execute();
+
+    const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
+    expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
+
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    
+    expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
+
+    expect(GitCLIService.prototype.cherryPick).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+
+    expect(GitCLIService.prototype.push).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+
+    expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
+    expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
+        owner: "owner", 
+        repo: "reponame", 
+        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        base: "target", 
+        title: "[target] PR Title", 
+        body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
+        reviewers: ["gh-user", "that-s-a-user"],
+        assignees: [],
+        labels: [],
+      }
+    );
+  });
+
 });

--- a/test/service/runner/gha-gitlab-runner.test.ts
+++ b/test/service/runner/gha-gitlab-runner.test.ts
@@ -6,6 +6,8 @@ import GHAArgsParser from "@bp/service/args/gha/gha-args-parser";
 import { createTestFile, removeTestFile, spyGetInput } from "../../support/utils";
 import { getAxiosMocked } from "../../support/mock/git-client-mock-support";
 import { MERGED_SQUASHED_MR } from "../../support/mock/gitlab-data";
+import GitClientFactory from "@bp/service/git/git-client-factory";
+import { GitClientType } from "@bp/service/git/git.types";
 
 const GITLAB_MERGED_PR_COMPLEX_CONFIG_FILE_CONTENT_PATHNAME = "./gha-gitlab-runner-pr-merged-with-overrides.json";
 const GITLAB_MERGED_PR_COMPLEX_CONFIG_FILE_CONTENT = {
@@ -41,6 +43,7 @@ jest.mock("axios", () => {
 
 jest.mock("@bp/service/git/git-cli");
 jest.spyOn(GitLabClient.prototype, "createPullRequest");
+jest.spyOn(GitClientFactory, "getOrCreate");
 
 let parser: ArgsParser;
 let runner: Runner;
@@ -79,6 +82,9 @@ describe("gha runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
@@ -104,6 +110,9 @@ describe("gha runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
@@ -154,6 +163,9 @@ describe("gha runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
@@ -198,6 +210,9 @@ describe("gha runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
@@ -246,6 +261,9 @@ describe("gha runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
@@ -288,6 +306,9 @@ describe("gha runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
@@ -328,6 +349,9 @@ describe("gha runner", () => {
 
     const cwd = process.cwd() + "/bp";
 
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, undefined, "https://my.gitlab.host.com/api/v4");
+
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
@@ -365,6 +389,9 @@ describe("gha runner", () => {
     await runner.execute();
 
     const cwd = process.cwd() + "/bp";
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITLAB, "my-token", "https://my.gitlab.host.com/api/v4");
 
     expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "prod");

--- a/test/support/mock/git-client-mock-support.ts
+++ b/test/support/mock/git-client-mock-support.ts
@@ -149,6 +149,13 @@ export const mockGitHubClient = (apiUrl = "https://api.github.com"): Moctokit =>
       data: {}
     });
 
+  mock.rest.issues
+    .addLabels()
+    .reply({
+      status: 200,
+      data: {}
+    });
+
 
   // invalid requests
   mock.rest.pulls


### PR DESCRIPTION
**Thank you for submitting this pull request**

fix https://github.com/kiegroup/git-backporting/issues/52

This is going to fix a regression introduced after `gitlab` extension, actually since version `v3.1.0`.

**Regression**: it was no longer possible to provide github api pull request url as pr source, e.g, `https://api.github.com/repos/owner/repo/pulls/1`

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [x] Tests added if applicable.
- [ ] Documentation updated if applicable.

> **Note:** `dist/cli/index.js` and `dist/gha/index.js` are automatically generated by git hooks and gh workflows.
