### PR TITLE
fix(issue-57): truncate the bp branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ---
 
-## :bangbang: Starting from v4 git-backporting has been moved under @kiegroup organization and renamed :bangbang:
+## :bangbang: Starting from v4 git-backporting has been moved under @kiegroup organization :bangbang:
 
 ---
 
@@ -109,7 +109,7 @@ This tool comes with some inputs that allow users to override the default behavi
 | Reviewers       | --reviewers        | N            | Backporting pull request comma-separated reviewers list                                                           | []       |
 | Assignees       | --assignes        | N            | Backporting pull request comma-separated assignees list                                                           | []       |
 | No Reviewers Inheritance       | --no-inherit-reviewers        | N            | Considered only if reviewers is empty, if true keep reviewers as empty list, otherwise inherit from original pull request                                                           | false       |
-| Backport Branch Name       | --bp-branch-name        | N            | Name of the backporting pull request branch                                                           | bp-{target-branch}-{sha}       |
+| Backport Branch Name       | --bp-branch-name        | N            | Name of the backporting pull request branch, if it exceeds 250 chars it will be truncated                                                           | bp-{target-branch}-{sha1}...{shaN}       |
 | Labels       | --labels        | N            | Provide custom labels to be added to the backporting pull request                                                           | []       |
 | Inherit labels       | --inherit-labels        | N            | If enabled inherit lables from the original pull request                                                           | false       |
 | No squash       | --no-squash        | N            | If provided the backporting will try to backport all pull request commits without squashing                                                           | false       |

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -1192,7 +1192,16 @@ class Runner {
         await git.clone(configs.originalPullRequest.targetRepo.cloneUrl, configs.folder, configs.targetBranch);
         // 5. create new branch from target one and checkout
         this.logger.debug("Creating local branch..");
-        const backportBranch = backportPR.branchName ?? `bp-${configs.targetBranch}-${originalPR.commits.join("-")}`;
+        let backportBranch = backportPR.branchName;
+        if (backportBranch === undefined || backportBranch.trim() === "") {
+            // for each commit takes the first 7 chars that are enough to uniquely identify them in most of the projects
+            const concatenatedCommits = originalPR.commits.map(c => c.slice(0, 7)).join("-");
+            backportBranch = `bp-${configs.targetBranch}-${concatenatedCommits}`;
+        }
+        if (backportBranch.length > 250) {
+            this.logger.warn(`Backport branch (length=${backportBranch.length}) exceeded the max length of 250 chars, branch name truncated!`);
+            backportBranch = backportBranch.slice(0, 250);
+        }
         await git.createLocalBranch(configs.folder, backportBranch);
         // 6. fetch pull request remote if source owner != target owner or pull request still open
         if (configs.originalPullRequest.sourceRepo.owner !== configs.originalPullRequest.targetRepo.owner ||

--- a/src/service/runner/runner.ts
+++ b/src/service/runner/runner.ts
@@ -74,7 +74,18 @@ export default class Runner {
 
     // 5. create new branch from target one and checkout
     this.logger.debug("Creating local branch..");
-    const backportBranch = backportPR.branchName ?? `bp-${configs.targetBranch}-${originalPR.commits!.join("-")}`;
+    let backportBranch = backportPR.branchName;
+    if (backportBranch === undefined || backportBranch.trim() === "") {
+      // for each commit takes the first 7 chars that are enough to uniquely identify them in most of the projects
+      const concatenatedCommits: string = originalPR.commits!.map(c => c.slice(0, 7)).join("-");
+      backportBranch = `bp-${configs.targetBranch}-${concatenatedCommits}`;
+    }
+
+    if (backportBranch.length > 250) {
+      this.logger.warn(`Backport branch (length=${backportBranch.length}) exceeded the max length of 250 chars, branch name truncated!`);
+      backportBranch = backportBranch.slice(0, 250);
+    }
+
     await git.createLocalBranch(configs.folder, backportBranch);
 
     // 6. fetch pull request remote if source owner != target owner or pull request still open

--- a/test/service/runner/cli-github-runner.test.ts
+++ b/test/service/runner/cli-github-runner.test.ts
@@ -80,7 +80,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -109,7 +109,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -143,7 +143,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -180,7 +180,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -211,7 +211,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -220,13 +220,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        head: "bp-target-28f63db", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
@@ -256,7 +256,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
@@ -264,13 +264,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        head: "bp-target-28f63db", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/8632"),
@@ -311,7 +311,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-91748965051fae1330ad58d15cf694e103267c87");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9174896");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/4444/head:pr/4444");
@@ -320,13 +320,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "91748965051fae1330ad58d15cf694e103267c87");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-91748965051fae1330ad58d15cf694e103267c87");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-9174896");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-91748965051fae1330ad58d15cf694e103267c87", 
+        head: "bp-target-9174896", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/4444"),
@@ -472,7 +472,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -481,13 +481,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        head: "bp-target-28f63db", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
@@ -519,7 +519,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -528,13 +528,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        head: "bp-target-28f63db", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
@@ -608,7 +608,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -617,13 +617,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        head: "bp-target-28f63db", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
@@ -654,7 +654,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-0404fb922ab75c3a8aecad5c97d9af388df04695-11da4e38aa3e577ffde6d546f1c52e53b04d3151");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-0404fb9-11da4e3");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
@@ -663,16 +663,68 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "11da4e38aa3e577ffde6d546f1c52e53b04d3151");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-0404fb922ab75c3a8aecad5c97d9af388df04695-11da4e38aa3e577ffde6d546f1c52e53b04d3151");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-0404fb9-11da4e3");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-0404fb922ab75c3a8aecad5c97d9af388df04695-11da4e38aa3e577ffde6d546f1c52e53b04d3151", 
+        head: "bp-target-0404fb9-11da4e3", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/8632"),
+        reviewers: ["gh-user", "that-s-a-user"],
+        assignees: [],
+        labels: [],
+      }
+    );
+  });
+
+  test("too long bp branch name", async () => {
+    // 260 chars
+    const tooLongBranchName = "too-long-branch-name".repeat(13);
+
+    addProcessArgs([
+      "-tb",
+      "target",
+      "-pr",
+      "https://github.com/owner/reponame/pull/2368",
+      "--bp-branch-name",
+      tooLongBranchName,
+    ]);
+    
+    await runner.execute();
+
+    const cwd = process.cwd() + "/bp";
+
+    const truncatedBranch = tooLongBranchName.slice(0, 250);
+
+    expect(GitClientFactory.getOrCreate).toBeCalledTimes(1);
+    expect(GitClientFactory.getOrCreate).toBeCalledWith(GitClientType.GITHUB, undefined, "https://api.github.com");
+
+    expect(GitCLIService.prototype.clone).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
+
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, truncatedBranch);
+    
+    expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
+
+    expect(GitCLIService.prototype.cherryPick).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+
+    expect(GitCLIService.prototype.push).toBeCalledTimes(1);
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, truncatedBranch);
+
+    expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
+    expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
+        owner: "owner", 
+        repo: "reponame", 
+        head: truncatedBranch, 
+        base: "target", 
+        title: "[target] PR Title", 
+        body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
         reviewers: ["gh-user", "that-s-a-user"],
         assignees: [],
         labels: [],

--- a/test/service/runner/cli-gitlab-runner.test.ts
+++ b/test/service/runner/cli-gitlab-runner.test.ts
@@ -91,7 +91,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9e15674ebd48e05c6e428a1fa31dbb60a778d644");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9e15674");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "merge-requests/2/head:pr/2");
@@ -125,7 +125,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9e15674ebd48e05c6e428a1fa31dbb60a778d644");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9e15674");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "merge-requests/2/head:pr/2");
@@ -159,7 +159,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9e15674ebd48e05c6e428a1fa31dbb60a778d644");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9e15674");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "merge-requests/2/head:pr/2");
@@ -168,13 +168,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "9e15674ebd48e05c6e428a1fa31dbb60a778d644");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-9e15674ebd48e05c6e428a1fa31dbb60a778d644");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-9e15674");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-target-9e15674ebd48e05c6e428a1fa31dbb60a778d644", 
+        head: "bp-target-9e15674", 
         base: "target", 
         title: "[target] Update test.txt opened", 
         body: expect.stringContaining("**Backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/2"),
@@ -215,7 +215,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca");
     
     // 0 occurrences as the mr is already merged and the owner is the same for
     // both source and target repositories
@@ -225,13 +225,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "ebb1eca696c42fd067658bd9b5267709f78ef38e");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e", 
+        head: "bp-target-ebb1eca", 
         base: "target", 
         title: "[target] Update test.txt", 
         body: expect.stringContaining("**Backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/1"),
@@ -378,7 +378,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca");
     
     // 0 occurrences as the mr is already merged and the owner is the same for
     // both source and target repositories
@@ -388,13 +388,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "ebb1eca696c42fd067658bd9b5267709f78ef38e");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e", 
+        head: "bp-target-ebb1eca", 
         base: "target", 
         title: "[target] Update test.txt", 
         body: expect.stringContaining("**Backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/1"),
@@ -426,7 +426,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca");
     
     // 0 occurrences as the mr is already merged and the owner is the same for
     // both source and target repositories
@@ -436,13 +436,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "ebb1eca696c42fd067658bd9b5267709f78ef38e");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e", 
+        head: "bp-target-ebb1eca", 
         base: "target", 
         title: "[target] Update test.txt", 
         body: expect.stringContaining("**Backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/1"),
@@ -470,7 +470,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "prod");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-prod-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-prod-ebb1eca");
     
     // 0 occurrences as the mr is already merged and the owner is the same for
     // both source and target repositories
@@ -480,13 +480,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "ebb1eca696c42fd067658bd9b5267709f78ef38e");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-prod-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-prod-ebb1eca");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-prod-ebb1eca696c42fd067658bd9b5267709f78ef38e", 
+        head: "bp-prod-ebb1eca", 
         base: "prod", 
         title: "New Title", 
         body: expect.stringContaining("**This is a backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/1"),
@@ -517,7 +517,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-e4dd336a4a20f394df6665994df382fb1d193a11-974519f65c9e0ed65277cd71026657a09fca05e7");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-e4dd336-974519f");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "merge-requests/2/head:pr/2");
@@ -527,13 +527,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "974519f65c9e0ed65277cd71026657a09fca05e7");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-e4dd336a4a20f394df6665994df382fb1d193a11-974519f65c9e0ed65277cd71026657a09fca05e7");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-e4dd336-974519f");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-target-e4dd336a4a20f394df6665994df382fb1d193a11-974519f65c9e0ed65277cd71026657a09fca05e7",
+        head: "bp-target-e4dd336-974519f",
         base: "target", 
         title: "[target] Update test.txt opened", 
         body: expect.stringContaining("**Backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/2"),

--- a/test/service/runner/gha-github-runner.test.ts
+++ b/test/service/runner/gha-github-runner.test.ts
@@ -74,7 +74,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -103,7 +103,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -112,13 +112,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        head: "bp-target-28f63db", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
@@ -155,7 +155,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-91748965051fae1330ad58d15cf694e103267c87");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9174896");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/4444/head:pr/4444");
@@ -164,13 +164,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "91748965051fae1330ad58d15cf694e103267c87");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-91748965051fae1330ad58d15cf694e103267c87");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-9174896");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-91748965051fae1330ad58d15cf694e103267c87", 
+        head: "bp-target-9174896", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/4444"),
@@ -299,7 +299,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -308,13 +308,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        head: "bp-target-28f63db", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
@@ -344,7 +344,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -353,13 +353,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        head: "bp-target-28f63db", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
@@ -430,7 +430,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-28f63db");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/2368/head:pr/2368");
@@ -439,13 +439,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-28f63db");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-28f63db774185f4ec4b57cd9aaeb12dbfb4c9ecc", 
+        head: "bp-target-28f63db", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/2368"),
@@ -474,7 +474,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://github.com/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-0404fb922ab75c3a8aecad5c97d9af388df04695-11da4e38aa3e577ffde6d546f1c52e53b04d3151");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-0404fb9-11da4e3");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
@@ -483,13 +483,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "11da4e38aa3e577ffde6d546f1c52e53b04d3151");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-0404fb922ab75c3a8aecad5c97d9af388df04695-11da4e38aa3e577ffde6d546f1c52e53b04d3151");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-0404fb9-11da4e3");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-0404fb922ab75c3a8aecad5c97d9af388df04695-11da4e38aa3e577ffde6d546f1c52e53b04d3151", 
+        head: "bp-target-0404fb9-11da4e3", 
         base: "target", 
         title: "[target] PR Title", 
         body: expect.stringContaining("**Backport:** https://github.com/owner/reponame/pull/8632"),

--- a/test/service/runner/gha-gitlab-runner.test.ts
+++ b/test/service/runner/gha-gitlab-runner.test.ts
@@ -85,7 +85,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9e15674ebd48e05c6e428a1fa31dbb60a778d644");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9e15674");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "merge-requests/2/head:pr/2");
@@ -114,7 +114,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9e15674ebd48e05c6e428a1fa31dbb60a778d644");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-9e15674");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "merge-requests/2/head:pr/2");
@@ -123,13 +123,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "9e15674ebd48e05c6e428a1fa31dbb60a778d644");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-9e15674ebd48e05c6e428a1fa31dbb60a778d644");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-9e15674");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-target-9e15674ebd48e05c6e428a1fa31dbb60a778d644", 
+        head: "bp-target-9e15674", 
         base: "target", 
         title: "[target] Update test.txt opened", 
         body: expect.stringContaining("**Backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/2"),
@@ -166,7 +166,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
@@ -174,13 +174,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "ebb1eca696c42fd067658bd9b5267709f78ef38e");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e", 
+        head: "bp-target-ebb1eca", 
         base: "target", 
         title: "[target] Update test.txt", 
         body: expect.stringContaining("**Backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/1"),
@@ -309,7 +309,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
@@ -317,13 +317,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "ebb1eca696c42fd067658bd9b5267709f78ef38e");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e", 
+        head: "bp-target-ebb1eca", 
         base: "target", 
         title: "[target] Update test.txt", 
         body: expect.stringContaining("**Backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/1"),
@@ -352,7 +352,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-ebb1eca");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
@@ -360,13 +360,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "ebb1eca696c42fd067658bd9b5267709f78ef38e");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-ebb1eca");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-target-ebb1eca696c42fd067658bd9b5267709f78ef38e", 
+        head: "bp-target-ebb1eca", 
         base: "target", 
         title: "[target] Update test.txt", 
         body: expect.stringContaining("**Backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/1"),
@@ -393,7 +393,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "prod");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-prod-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-prod-ebb1eca");
     
     // 0 occurrences as the mr is already merged and the owner is the same for
     // both source and target repositories
@@ -403,13 +403,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "ebb1eca696c42fd067658bd9b5267709f78ef38e");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-prod-ebb1eca696c42fd067658bd9b5267709f78ef38e");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-prod-ebb1eca");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-prod-ebb1eca696c42fd067658bd9b5267709f78ef38e", 
+        head: "bp-prod-ebb1eca", 
         base: "prod", 
         title: "New Title", 
         body: expect.stringContaining("**This is a backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/1"),
@@ -438,7 +438,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://my.gitlab.host.com/superuser/backporting-example.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-e4dd336a4a20f394df6665994df382fb1d193a11-974519f65c9e0ed65277cd71026657a09fca05e7");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-e4dd336-974519f");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "merge-requests/2/head:pr/2");
@@ -448,13 +448,13 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "974519f65c9e0ed65277cd71026657a09fca05e7");
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-e4dd336a4a20f394df6665994df382fb1d193a11-974519f65c9e0ed65277cd71026657a09fca05e7");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-e4dd336-974519f");
 
     expect(GitLabClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitLabClient.prototype.createPullRequest).toBeCalledWith({
         owner: "superuser", 
         repo: "backporting-example", 
-        head: "bp-target-e4dd336a4a20f394df6665994df382fb1d193a11-974519f65c9e0ed65277cd71026657a09fca05e7",
+        head: "bp-target-e4dd336-974519f",
         base: "target", 
         title: "[target] Update test.txt opened", 
         body: expect.stringContaining("**Backport:** https://my.gitlab.host.com/superuser/backporting-example/-/merge_requests/2"),


### PR DESCRIPTION
**Thank you for submitting this pull request**

fix: https://github.com/kiegroup/git-backporting/issues/57

This change will ensure that if the provided/generated backport branch name exceede the maximum branch name length set for git, which is 250 chars, it truncates that name to 250 chars exactly.

In order to include as much commits as possible the branch name will contain by default the shortened version of all commits

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

### Checklist
- [x] Tests added if applicable.
- [x] Documentation updated if applicable.

> **Note:** `dist/cli/index.js` and `dist/gha/index.js` are automatically generated by git hooks and gh workflows.

<details>
<summary>
First time here?
</summary>

This project follows [git conventional commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) pattern, therefore the commits should have the following format:

```
<type>(<optional scope>): <subject>
empty separator line
<optional body>
empty separator line
<optional footer>
```

Where the type must be one of `[build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]`

> **NOTE**: if you are still in a `work in progress` branch and you want to push your changes remotely, consider adding `--no-verify` for both `commit` and `push`, e.g., `git push origin <feat-branch> --no-verify` - this could become useful to push changes where there are still tests failures. Once the pull request is ready, please `amend` the commit and force-push it to keep following the adopted git commit standard. 

</details>

<details>
<summary>
How to prepare for a new release?
</summary>

There is no need to manually update `package.json` version and `CHANGELOG.md` information. This process has been automated in [Prepare Release](./workflows/prepare-release.yml) *Github* workflow.

Therefore whenever enough changes are merged into the `main` branch, one of the maintainers will trigger this workflow that will automatically update `version` and `changelog` based on the commits on the git tree.

More details can be found in [package release](https://github.com/kiegroup/git-backporting/blob/main/README.md#package-release) section of the README.
</details>