### PR TITLE
feat(gh-85): take git tokens from env variables at first

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This tool comes with some inputs that allow users to override the default behavi
 | Target Branches | -tb, --target-branch | N            | Comma separated list of branches where the changes must be backported to                                                                                                         |             |
 | Pull Request  | -pr, --pull-request  | N            | Original pull request url, the one that must be backported, e.g., https://github.com/kiegroup/git-backporting/pull/1                                        |             |
 | Configuration File  | -cf, --config-file  | N            | Configuration file, in JSON format, containing all options to be overridded, note that if provided all other CLI options will be ignored                                        |             |
-| Auth          | -a, --auth           | N            | `GITHUB_TOKEN`, `GITLAB_TOKEN` or a `repo` scoped [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) | ""          |
+| Auth          | -a, --auth           | N            | Git access/authorization token, if provided all token env variables will be ignored. See [auth token](#authorization-token) section for more details | ""          |
 | Folder        | -f, --folder         | N            | Local folder full name of the repository that will be checked out, e.g., /tmp/folder                                                                                     | {cwd}/bp    |
 | Git User       | -gu, --git-user        | N            | Local git user name                                                       | "GitHub"       |
 | Git Email       | -ge, --git-email        | N            | Local git user email                                                       | "noreply@github.com"       |
@@ -117,6 +117,17 @@ This tool comes with some inputs that allow users to override the default behavi
 | Dry Run       | -d, --dry-run        | N            | If enabled the tool does not push nor create anything remotely, use this to skip PR creation                                                           | false       |
 
 > **NOTE**: `pull request` and `target branch` are *mandatory*, they must be provided as CLI options or as part of the configuration file (if used).
+
+#### Authorization token
+
+Since version `4.5.0` we introduced a new feature that allows user to provide the git access token through environment variables. These env variables are taken into consideration only if the `--auth/-a` is not provided as argument/input.
+Here the supported list of env variables:
+- `GITHUB_TOKEN`: this is checked only if backporting on Github platform.
+- `GITLAB_TOKEN`: this is checked only if backporting on Gitlab platform.
+- `CODEBERG_TOKEN`: this is checked only if backporting on Codeberg platform.
+- `GIT_TOKEN`: this is considered if none of the previous envs are set.
+
+> **NOTE**: if `--auth` argument is provided, all env variables will be ignored even if not empty.
 
 #### Configuration file example
 
@@ -194,6 +205,9 @@ on:
       - closed
       - labeled
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   backporting:
     name: "Backporting"
@@ -216,7 +230,6 @@ jobs:
         with:
           target-branch: v1
           pull-request: ${{ github.event.pull_request.url }}
-          auth: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 For a complete description of all inputs see [Inputs section](#inputs).

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: "false"
   auth:
-    description: "GITHUB_TOKEN or a `repo` scoped Personal Access Token (PAT)"
+    description: "GITHUB_TOKEN or a `repo` scoped Personal Access Token (PAT), if not provided will look for existing env variables like GITHUB_TOKEN"
     default: ${{ github.token }}
     required: false
   git-user:

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -182,7 +182,7 @@ class CLIArgsParser extends args_parser_1.default {
             .option("-tb, --target-branch <branches>", "comma separated list of branches where changes must be backported to")
             .option("-pr, --pull-request <pr-url>", "pull request url, e.g., https://github.com/kiegroup/git-backporting/pull/1")
             .option("-d, --dry-run", "if enabled the tool does not create any pull request nor push anything remotely")
-            .option("-a, --auth <auth>", "git service authentication string, e.g., github token")
+            .option("-a, --auth <auth>", "git authentication string, if not provided fallback by looking for existing env variables like GITHUB_TOKEN")
             .option("-gu, --git-user <git-user>", "local git user name, default is 'GitHub'")
             .option("-ge, --git-email <git-email>", "local git user email, default is 'noreply@github.com'")
             .option("-f, --folder <folder>", "local folder where the repo will be checked out, e.g., /tmp/folder")
@@ -251,7 +251,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+const configs_types_1 = __nccwpck_require__(4753);
 const logger_service_factory_1 = __importDefault(__nccwpck_require__(8936));
+const git_types_1 = __nccwpck_require__(750);
 /**
  * Abstract configuration parser class in charge to parse
  * Args and produces a common Configs object
@@ -273,8 +275,66 @@ class ConfigsParser {
         }
         return Promise.resolve(configs);
     }
+    /**
+     * Retrieve the git token from env variable, the default is taken from GIT_TOKEN env.
+     * All specific git env variable have precedence and override the default one.
+     * @param gitType
+     * @returns tuple where
+     *      - the first element is the corresponding env value
+     *      - the second element is true if the value is not undefined nor empty
+     */
+    getGitTokenFromEnv(gitType) {
+        let [token] = this.getEnv(configs_types_1.AuthTokenId.GIT_TOKEN);
+        let [specToken, specOk] = [undefined, false];
+        if (git_types_1.GitClientType.GITHUB == gitType) {
+            [specToken, specOk] = this.getEnv(configs_types_1.AuthTokenId.GITHUB_TOKEN);
+        }
+        else if (git_types_1.GitClientType.GITLAB == gitType) {
+            [specToken, specOk] = this.getEnv(configs_types_1.AuthTokenId.GITLAB_TOKEN);
+        }
+        else if (git_types_1.GitClientType.CODEBERG == gitType) {
+            [specToken, specOk] = this.getEnv(configs_types_1.AuthTokenId.CODEBERG_TOKEN);
+        }
+        if (specOk) {
+            token = specToken;
+        }
+        return token;
+    }
+    /**
+     * Get process env variable given the input key string
+     * @param key
+     * @returns tuple where
+     *      - the first element is the corresponding env value
+     *      - the second element is true if the value is not undefined nor empty
+     */
+    getEnv(key) {
+        const val = process.env[key];
+        return [val, val !== undefined && val !== ""];
+    }
 }
 exports["default"] = ConfigsParser;
+
+
+/***/ }),
+
+/***/ 4753:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.AuthTokenId = void 0;
+var AuthTokenId;
+(function (AuthTokenId) {
+    // github specific token
+    AuthTokenId["GITHUB_TOKEN"] = "GITHUB_TOKEN";
+    // gitlab specific token
+    AuthTokenId["GITLAB_TOKEN"] = "GITLAB_TOKEN";
+    // codeberg specific token
+    AuthTokenId["CODEBERG_TOKEN"] = "CODEBERG_TOKEN";
+    // generic git token
+    AuthTokenId["GIT_TOKEN"] = "GIT_TOKEN";
+})(AuthTokenId = exports.AuthTokenId || (exports.AuthTokenId = {}));
 
 
 /***/ }),
@@ -311,9 +371,18 @@ class PullRequestConfigsParser extends configs_parser_1.default {
         if (bpBranchNames.length > 1 && bpBranchNames.length != targetBranches.length) {
             throw new Error(`The number of backport branch names, if provided, must match the number of target branches or just one, provided ${bpBranchNames.length} branch names instead`);
         }
+        // setup the auth token
+        let token = args.auth;
+        if (token === undefined) {
+            this.logger.info("Auth argument not provided, checking available tokens from env..");
+            token = this.getGitTokenFromEnv(this.gitClient.getClientType());
+            if (!token) {
+                this.logger.info("Git token not set in the env");
+            }
+        }
         return {
             dryRun: args.dryRun,
-            auth: args.auth,
+            auth: token,
             folder: `${folder.startsWith("/") ? "" : process.cwd() + "/"}${args.folder ?? this.getDefaultFolder()}`,
             mergeStrategy: args.strategy,
             mergeStrategyOption: args.strategyOption,
@@ -567,7 +636,7 @@ class GitClientFactory {
                 GitClientFactory.instance = new gitlab_client_1.default(authToken, apiUrl);
                 break;
             case git_types_1.GitClientType.CODEBERG:
-                GitClientFactory.instance = new github_client_1.default(authToken, apiUrl);
+                GitClientFactory.instance = new github_client_1.default(authToken, apiUrl, true);
                 break;
             default:
                 throw new Error(`Invalid git service type received: ${type}`);
@@ -673,11 +742,15 @@ const github_mapper_1 = __importDefault(__nccwpck_require__(5764));
 const octokit_factory_1 = __importDefault(__nccwpck_require__(4257));
 const logger_service_factory_1 = __importDefault(__nccwpck_require__(8936));
 class GitHubClient {
-    constructor(token, apiUrl) {
+    constructor(token, apiUrl, isForCodeberg = false) {
         this.apiUrl = apiUrl;
+        this.isForCodeberg = isForCodeberg;
         this.logger = logger_service_factory_1.default.getLogger();
         this.octokit = octokit_factory_1.default.getOctokit(token, this.apiUrl);
         this.mapper = new github_mapper_1.default();
+    }
+    getClientType() {
+        return this.isForCodeberg ? git_types_1.GitClientType.CODEBERG : git_types_1.GitClientType.GITHUB;
     }
     // READ
     getDefaultGitUser() {
@@ -889,6 +962,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+const git_types_1 = __nccwpck_require__(750);
 const logger_service_factory_1 = __importDefault(__nccwpck_require__(8936));
 const gitlab_mapper_1 = __importDefault(__nccwpck_require__(2675));
 const axios_1 = __importDefault(__nccwpck_require__(8757));
@@ -908,6 +982,9 @@ class GitLabClient {
             })
         });
         this.mapper = new gitlab_mapper_1.default(this.client);
+    }
+    getClientType() {
+        return git_types_1.GitClientType.GITLAB;
     }
     getDefaultGitUser() {
         return "Gitlab";

--- a/src/service/args/cli/cli-args-parser.ts
+++ b/src/service/args/cli/cli-args-parser.ts
@@ -13,7 +13,7 @@ export default class CLIArgsParser extends ArgsParser {
       .option("-tb, --target-branch <branches>", "comma separated list of branches where changes must be backported to")
       .option("-pr, --pull-request <pr-url>", "pull request url, e.g., https://github.com/kiegroup/git-backporting/pull/1")
       .option("-d, --dry-run", "if enabled the tool does not create any pull request nor push anything remotely")
-      .option("-a, --auth <auth>", "git service authentication string, e.g., github token")
+      .option("-a, --auth <auth>", "git authentication string, if not provided fallback by looking for existing env variables like GITHUB_TOKEN")
       .option("-gu, --git-user <git-user>", "local git user name, default is 'GitHub'")
       .option("-ge, --git-email <git-email>", "local git user email, default is 'noreply@github.com'")
       .option("-f, --folder <folder>", "local folder where the repo will be checked out, e.g., /tmp/folder")

--- a/src/service/configs/configs-parser.ts
+++ b/src/service/configs/configs-parser.ts
@@ -1,7 +1,8 @@
 import { Args } from "@bp/service/args/args.types";
-import { Configs } from "@bp/service/configs/configs.types";
+import { AuthTokenId, Configs } from "@bp/service/configs/configs.types";
 import LoggerService from "../logger/logger-service";
 import LoggerServiceFactory from "../logger/logger-service-factory";
+import { GitClientType } from "../git/git.types";
 
 /**
  * Abstract configuration parser class in charge to parse 
@@ -33,5 +34,43 @@ import LoggerServiceFactory from "../logger/logger-service-factory";
     }
 
     return Promise.resolve(configs);
+  }
+
+  /**
+   * Retrieve the git token from env variable, the default is taken from GIT_TOKEN env.
+   * All specific git env variable have precedence and override the default one.
+   * @param gitType 
+   * @returns tuple where 
+   *      - the first element is the corresponding env value
+   *      - the second element is true if the value is not undefined nor empty
+   */
+  public getGitTokenFromEnv(gitType: GitClientType): string | undefined {
+    let [token] = this.getEnv(AuthTokenId.GIT_TOKEN);
+    let [specToken, specOk]: [string | undefined, boolean] = [undefined, false];
+    if (GitClientType.GITHUB == gitType) {
+      [specToken, specOk] = this.getEnv(AuthTokenId.GITHUB_TOKEN);
+    } else if (GitClientType.GITLAB == gitType) {
+      [specToken, specOk] = this.getEnv(AuthTokenId.GITLAB_TOKEN);
+    } else if (GitClientType.CODEBERG == gitType) {
+      [specToken, specOk] = this.getEnv(AuthTokenId.CODEBERG_TOKEN);
+    }
+
+    if (specOk) {
+      token = specToken;
+    }
+
+    return token;
+  }
+
+  /**
+   * Get process env variable given the input key string
+   * @param key 
+   * @returns tuple where 
+   *      - the first element is the corresponding env value
+   *      - the second element is true if the value is not undefined nor empty
+   */
+  public getEnv(key: string): [string | undefined, boolean] {
+    const val = process.env[key];
+    return [val, val !== undefined && val !== ""];
   }
 }

--- a/src/service/configs/configs.types.ts
+++ b/src/service/configs/configs.types.ts
@@ -21,3 +21,13 @@ export interface Configs {
   backportPullRequests: BackportPullRequest[],
  }
 
+export enum AuthTokenId {
+  // github specific token
+  GITHUB_TOKEN = "GITHUB_TOKEN",
+  // gitlab specific token
+  GITLAB_TOKEN = "GITLAB_TOKEN",
+  // codeberg specific token
+  CODEBERG_TOKEN = "CODEBERG_TOKEN",
+  // generic git token
+  GIT_TOKEN = "GIT_TOKEN",
+}

--- a/src/service/configs/pullrequest/pr-configs-parser.ts
+++ b/src/service/configs/pullrequest/pr-configs-parser.ts
@@ -33,9 +33,19 @@ export default class PullRequestConfigsParser extends ConfigsParser {
       throw new Error(`The number of backport branch names, if provided, must match the number of target branches or just one, provided ${bpBranchNames.length} branch names instead`);
     }
 
+    // setup the auth token
+    let token = args.auth;
+    if (token === undefined) {
+      this.logger.info("Auth argument not provided, checking available tokens from env..");
+      token = this.getGitTokenFromEnv(this.gitClient.getClientType());
+      if (!token) {
+        this.logger.info("Git token not set in the env");
+      }
+    }
+
     return {
       dryRun: args.dryRun!,
-      auth: args.auth,
+      auth: token,
       folder: `${folder.startsWith("/") ? "" : process.cwd() + "/"}${args.folder ?? this.getDefaultFolder()}`,
       mergeStrategy: args.strategy,
       mergeStrategyOption: args.strategyOption,

--- a/src/service/git/git-client-factory.ts
+++ b/src/service/git/git-client-factory.ts
@@ -44,7 +44,7 @@ export default class GitClientFactory {
         GitClientFactory.instance = new GitLabClient(authToken, apiUrl);
         break;
       case GitClientType.CODEBERG:
-        GitClientFactory.instance = new GitHubService(authToken, apiUrl);
+        GitClientFactory.instance = new GitHubService(authToken, apiUrl, true);
         break;
       default:
         throw new Error(`Invalid git service type received: ${type}`);

--- a/src/service/git/git-client.ts
+++ b/src/service/git/git-client.ts
@@ -1,10 +1,15 @@
-import { BackportPullRequest, GitPullRequest } from "@bp/service/git/git.types";
+import { BackportPullRequest, GitClientType, GitPullRequest } from "@bp/service/git/git.types";
 
 /**
  * Git management service interface, which provides a common API for interacting 
  * with several git management services like GitHub, Gitlab or Bitbucket.
  */
  export default interface GitClient {
+
+  /**
+   * @returns {GitClientType} specific git client enum type
+   */
+  getClientType(): GitClientType
 
   // READ
   

--- a/src/service/git/github/github-client.ts
+++ b/src/service/git/github/github-client.ts
@@ -11,14 +11,20 @@ export default class GitHubClient implements GitClient {
   
   private logger: LoggerService;
   private apiUrl: string;
+  private isForCodeberg: boolean;
   private octokit: Octokit;
   private mapper: GitHubMapper;
 
-  constructor(token: string | undefined, apiUrl: string) {
+  constructor(token: string | undefined, apiUrl: string, isForCodeberg = false) {
     this.apiUrl = apiUrl;
+    this.isForCodeberg = isForCodeberg;
     this.logger = LoggerServiceFactory.getLogger();
     this.octokit = OctokitFactory.getOctokit(token, this.apiUrl);
     this.mapper = new GitHubMapper();
+  }
+
+  getClientType(): GitClientType {
+    return this.isForCodeberg ? GitClientType.CODEBERG : GitClientType.GITHUB;
   }
 
   // READ

--- a/src/service/git/gitlab/gitlab-client.ts
+++ b/src/service/git/gitlab/gitlab-client.ts
@@ -1,6 +1,6 @@
 import LoggerService from "@bp/service/logger/logger-service";
 import GitClient from "@bp/service/git/git-client";
-import { GitPullRequest, BackportPullRequest } from "@bp/service/git/git.types";
+import { GitPullRequest, BackportPullRequest, GitClientType } from "@bp/service/git/git.types";
 import LoggerServiceFactory from "@bp/service/logger/logger-service-factory";
 import { CommitSchema, MergeRequestSchema, UserSchema } from "@gitbeaker/rest";
 import GitLabMapper from "@bp/service/git/gitlab/gitlab-mapper";
@@ -28,6 +28,10 @@ export default class GitLabClient implements GitClient {
       })
     });
     this.mapper = new GitLabMapper(this.client);
+  }
+
+  getClientType(): GitClientType {
+    return GitClientType.GITLAB;
   }
 
   getDefaultGitUser(): string {

--- a/test/service/configs/pullrequest/github-pr-configs-parser-multiple.test.ts
+++ b/test/service/configs/pullrequest/github-pr-configs-parser-multiple.test.ts
@@ -4,7 +4,7 @@ import PullRequestConfigsParser from "@bp/service/configs/pullrequest/pr-configs
 import GitClientFactory from "@bp/service/git/git-client-factory";
 import { GitClientType } from "@bp/service/git/git.types";
 import { mockGitHubClient } from "../../../support/mock/git-client-mock-support";
-import { resetProcessArgs } from "../../../support/utils";
+import { resetEnvTokens, resetProcessArgs } from "../../../support/utils";
 import { MERGED_PR_FIXTURE, REPO, TARGET_OWNER, MULT_COMMITS_PR_FIXTURE } from "../../../support/mock/github-data";
 import GitHubMapper from "@bp/service/git/github/github-mapper";
 import GitHubClient from "@bp/service/git/github/github-client";
@@ -28,6 +28,9 @@ describe("github pull request config parser", () => {
     // reset process.env variables
     resetProcessArgs();
 
+    // reset env tokens
+    resetEnvTokens();
+    
     // mock octokit
     mockGitHubClient("http://localhost/api/v3");
 

--- a/test/service/configs/pullrequest/gitlab-pr-configs-parser-multiple.test.ts
+++ b/test/service/configs/pullrequest/gitlab-pr-configs-parser-multiple.test.ts
@@ -7,6 +7,7 @@ import { getAxiosMocked } from "../../../support/mock/git-client-mock-support";
 import { MERGED_SQUASHED_MR } from "../../../support/mock/gitlab-data";
 import GitLabClient from "@bp/service/git/gitlab/gitlab-client";
 import GitLabMapper from "@bp/service/git/gitlab/gitlab-mapper";
+import { resetEnvTokens } from "../../../support/utils";
 
 jest.spyOn(GitLabMapper.prototype, "mapPullRequest");
 jest.spyOn(GitLabClient.prototype, "getPullRequest");
@@ -31,6 +32,9 @@ describe("gitlab merge request config parser", () => {
   });
 
   beforeEach(() => {
+    // reset env tokens
+    resetEnvTokens();
+
     configParser = new PullRequestConfigsParser();
   });
 

--- a/test/support/utils.ts
+++ b/test/support/utils.ts
@@ -1,4 +1,5 @@
 import * as core from "@actions/core";
+import { AuthTokenId } from "@bp/service/configs/configs.types";
 import * as fs from "fs";
 
 export const addProcessArgs = (args: string[]) => {
@@ -7,6 +8,13 @@ export const addProcessArgs = (args: string[]) => {
 
 export const resetProcessArgs = () => {
   process.argv = ["node", "backporting"];
+};
+
+export const resetEnvTokens = () => {
+  delete process.env[AuthTokenId.GITHUB_TOKEN];
+  delete process.env[AuthTokenId.GITLAB_TOKEN];
+  delete process.env[AuthTokenId.CODEBERG_TOKEN];
+  delete process.env[AuthTokenId.GIT_TOKEN];
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
**Thank you for submitting this pull request**

fixes https://github.com/kiegroup/git-backporting/issues/85

### Checklist
- [x] Tests added if applicable.
- [x] Documentation updated if applicable.

> **Note:** `dist/cli/index.js` and `dist/gha/index.js` are automatically generated by git hooks and gh workflows.

<details>
<summary>
First time here?
</summary>

This project follows [git conventional commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) pattern, therefore the commits should have the following format:

```
<type>(<optional scope>): <subject>
empty separator line
<optional body>
empty separator line
<optional footer>
```

Where the type must be one of `[build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]`

> **NOTE**: if you are still in a `work in progress` branch and you want to push your changes remotely, consider adding `--no-verify` for both `commit` and `push`, e.g., `git push origin <feat-branch> --no-verify` - this could become useful to push changes where there are still tests failures. Once the pull request is ready, please `amend` the commit and force-push it to keep following the adopted git commit standard. 

</details>

<details>
<summary>
How to prepare for a new release?
</summary>

There is no need to manually update `package.json` version and `CHANGELOG.md` information. This process has been automated in [Prepare Release](./workflows/prepare-release.yml) *Github* workflow.

Therefore whenever enough changes are merged into the `main` branch, one of the maintainers will trigger this workflow that will automatically update `version` and `changelog` based on the commits on the git tree.

More details can be found in [package release](https://github.com/kiegroup/git-backporting/blob/main/README.md#package-release) section of the README.
</details>