### PR TITLE
fix: --auth when --git-user contains space

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -493,8 +493,9 @@ class GitCLIService {
      * @param remoteURL remote link, e.g., https://github.com/kiegroup/git-backporting-example.git
      */
     remoteWithAuth(remoteURL) {
-        if (this.auth && this.gitData.user) {
-            return remoteURL.replace("://", `://${this.gitData.user}:${this.auth}@`);
+        if (this.auth) {
+            // Anything will work as a username.
+            return remoteURL.replace("://", `://token:${this.auth}@`);
         }
         // return remote as it is
         return remoteURL;

--- a/dist/gha/index.js
+++ b/dist/gha/index.js
@@ -463,8 +463,9 @@ class GitCLIService {
      * @param remoteURL remote link, e.g., https://github.com/kiegroup/git-backporting-example.git
      */
     remoteWithAuth(remoteURL) {
-        if (this.auth && this.gitData.user) {
-            return remoteURL.replace("://", `://${this.gitData.user}:${this.auth}@`);
+        if (this.auth) {
+            // Anything will work as a username.
+            return remoteURL.replace("://", `://token:${this.auth}@`);
         }
         // return remote as it is
         return remoteURL;

--- a/src/service/git/git-cli.ts
+++ b/src/service/git/git-cli.ts
@@ -35,8 +35,9 @@ export default class GitCLIService {
    * @param remoteURL remote link, e.g., https://github.com/kiegroup/git-backporting-example.git
    */
   private remoteWithAuth(remoteURL: string): string {
-    if (this.auth && this.gitData.user) {
-      return remoteURL.replace("://", `://${this.gitData.user}:${this.auth}@`);
+    if (this.auth) {
+      // Anything will work as a username.
+      return remoteURL.replace("://", `://token:${this.auth}@`);
     }
 
     // return remote as it is

--- a/test/service/git/git-cli.test.ts
+++ b/test/service/git/git-cli.test.ts
@@ -123,4 +123,22 @@ describe("git cli service", () => {
     const post = spawnSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd }).stdout.toString().trim();
     expect(post).toEqual("tbranch");
   });
+
+  test("git clone set url with auth correctly for API token", async () => {
+    const git2 = new GitCLIService("api-token", {
+      user: "Backporting bot",
+      email: "bot@example.com",
+    });
+    const cwd2 = `${__dirname}/test-api-token`;
+
+    try {
+      await git2.clone(`file://${cwd}`, cwd2, "main");
+      const remoteURL = spawnSync("git", ["remote", "get-url", "origin"], { cwd: cwd2 }).stdout.toString().trim();
+
+      expect(remoteURL).toContain("api-token");
+      expect(remoteURL).not.toContain("Backporting bot");
+    } finally {
+      fs.rmSync(cwd2, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Since --git-user is a user-facing name, it's common to include a space in it. As such, it's not suitable to use as a username in a Git remote URL.

GitLab documented that it doesn't (yet?) check for username [1], and from my testing GitHub doesn't seem to care either. So just use an arbitrary name as a username.

[1] https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html

**Thank you for submitting this pull request**

### Checklist
- [X] Tests added if applicable.
- [ ] Documentation updated if applicable.

> **Note:** `dist/cli/index.js` and `dist/gha/index.js` are automatically generated by git hooks and gh workflows.

<details>
<summary>
First time here?
</summary>

This project follows [git conventional commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) pattern, therefore the commits should have the following format:

```
<type>(<optional scope>): <subject>
empty separator line
<optional body>
empty separator line
<optional footer>
```

Where the type must be one of `[build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]`

> **NOTE**: if you are still in a `work in progress` branch and you want to push your changes remotely, consider adding `--no-verify` for both `commit` and `push`, e.g., `git push origin <feat-branch> --no-verify` - this could become useful to push changes where there are still tests failures. Once the pull request is ready, please `amend` the commit and force-push it to keep following the adopted git commit standard. 

</details>

<details>
<summary>
How to prepare for a new release?
</summary>

There is no need to manually update `package.json` version and `CHANGELOG.md` information. This process has been automated in [Prepare Release](./workflows/prepare-release.yml) *Github* workflow.

Therefore whenever enough changes are merged into the `main` branch, one of the maintainers will trigger this workflow that will automatically update `version` and `changelog` based on the commits on the git tree.

More details can be found in [package release](https://github.com/kiegroup/git-backporting/blob/main/README.md#package-release) section of the README.
</details>