### PR TITLE
fix(gh-96): fix git token parsing

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -251,9 +251,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const configs_types_1 = __nccwpck_require__(4753);
 const logger_service_factory_1 = __importDefault(__nccwpck_require__(8936));
-const git_types_1 = __nccwpck_require__(750);
 /**
  * Abstract configuration parser class in charge to parse
  * Args and produces a common Configs object
@@ -274,42 +272,6 @@ class ConfigsParser {
             throw new Error("Provided pull request is closed and not merged");
         }
         return Promise.resolve(configs);
-    }
-    /**
-     * Retrieve the git token from env variable, the default is taken from GIT_TOKEN env.
-     * All specific git env variable have precedence and override the default one.
-     * @param gitType
-     * @returns tuple where
-     *      - the first element is the corresponding env value
-     *      - the second element is true if the value is not undefined nor empty
-     */
-    getGitTokenFromEnv(gitType) {
-        let [token] = this.getEnv(configs_types_1.AuthTokenId.GIT_TOKEN);
-        let [specToken, specOk] = [undefined, false];
-        if (git_types_1.GitClientType.GITHUB == gitType) {
-            [specToken, specOk] = this.getEnv(configs_types_1.AuthTokenId.GITHUB_TOKEN);
-        }
-        else if (git_types_1.GitClientType.GITLAB == gitType) {
-            [specToken, specOk] = this.getEnv(configs_types_1.AuthTokenId.GITLAB_TOKEN);
-        }
-        else if (git_types_1.GitClientType.CODEBERG == gitType) {
-            [specToken, specOk] = this.getEnv(configs_types_1.AuthTokenId.CODEBERG_TOKEN);
-        }
-        if (specOk) {
-            token = specToken;
-        }
-        return token;
-    }
-    /**
-     * Get process env variable given the input key string
-     * @param key
-     * @returns tuple where
-     *      - the first element is the corresponding env value
-     *      - the second element is true if the value is not undefined nor empty
-     */
-    getEnv(key) {
-        const val = process.env[key];
-        return [val, val !== undefined && val !== ""];
     }
 }
 exports["default"] = ConfigsParser;
@@ -371,18 +333,9 @@ class PullRequestConfigsParser extends configs_parser_1.default {
         if (bpBranchNames.length > 1 && bpBranchNames.length != targetBranches.length) {
             throw new Error(`The number of backport branch names, if provided, must match the number of target branches or just one, provided ${bpBranchNames.length} branch names instead`);
         }
-        // setup the auth token
-        let token = args.auth;
-        if (token === undefined) {
-            this.logger.info("Auth argument not provided, checking available tokens from env..");
-            token = this.getGitTokenFromEnv(this.gitClient.getClientType());
-            if (!token) {
-                this.logger.info("Git token not set in the env");
-            }
-        }
         return {
             dryRun: args.dryRun,
-            auth: token,
+            auth: args.auth,
             folder: `${folder.startsWith("/") ? "" : process.cwd() + "/"}${args.folder ?? this.getDefaultFolder()}`,
             mergeStrategy: args.strategy,
             mergeStrategyOption: args.strategyOption,
@@ -662,8 +615,9 @@ GitClientFactory.logger = logger_service_factory_1.default.getLogger();
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.inferGitApiUrl = exports.inferGitClient = void 0;
+exports.getEnv = exports.getGitTokenFromEnv = exports.inferGitApiUrl = exports.inferGitClient = void 0;
 const git_types_1 = __nccwpck_require__(750);
+const configs_types_1 = __nccwpck_require__(4753);
 const PUBLIC_GITHUB_URL = "https://github.com";
 const PUBLIC_GITHUB_API = "https://api.github.com";
 /**
@@ -701,6 +655,44 @@ const inferGitApiUrl = (prUrl, apiVersion = "v4") => {
     return `${baseUrl}/api/${apiVersion}`;
 };
 exports.inferGitApiUrl = inferGitApiUrl;
+/**
+ * Retrieve the git token from env variable, the default is taken from GIT_TOKEN env.
+ * All specific git env variable have precedence and override the default one.
+ * @param gitType
+ * @returns tuple where
+ *      - the first element is the corresponding env value
+ *      - the second element is true if the value is not undefined nor empty
+ */
+const getGitTokenFromEnv = (gitType) => {
+    let [token] = (0, exports.getEnv)(configs_types_1.AuthTokenId.GIT_TOKEN);
+    let [specToken, specOk] = [undefined, false];
+    if (git_types_1.GitClientType.GITHUB == gitType) {
+        [specToken, specOk] = (0, exports.getEnv)(configs_types_1.AuthTokenId.GITHUB_TOKEN);
+    }
+    else if (git_types_1.GitClientType.GITLAB == gitType) {
+        [specToken, specOk] = (0, exports.getEnv)(configs_types_1.AuthTokenId.GITLAB_TOKEN);
+    }
+    else if (git_types_1.GitClientType.CODEBERG == gitType) {
+        [specToken, specOk] = (0, exports.getEnv)(configs_types_1.AuthTokenId.CODEBERG_TOKEN);
+    }
+    if (specOk) {
+        token = specToken;
+    }
+    return token;
+};
+exports.getGitTokenFromEnv = getGitTokenFromEnv;
+/**
+ * Get process env variable given the input key string
+ * @param key
+ * @returns tuple where
+ *      - the first element is the corresponding env value
+ *      - the second element is true if the value is not undefined nor empty
+ */
+const getEnv = (key) => {
+    const val = process.env[key];
+    return [val, val !== undefined && val !== ""];
+};
+exports.getEnv = getEnv;
 
 
 /***/ }),
@@ -1354,9 +1346,11 @@ class Runner {
         const gitClientType = (0, git_util_1.inferGitClient)(args.pullRequest);
         // the api version is ignored in case of github
         const apiUrl = (0, git_util_1.inferGitApiUrl)(args.pullRequest, gitClientType === git_types_1.GitClientType.CODEBERG ? "v1" : undefined);
-        const gitApi = git_client_factory_1.default.getOrCreate(gitClientType, args.auth, apiUrl);
+        const token = this.fetchToken(args, gitClientType);
+        const gitApi = git_client_factory_1.default.getOrCreate(gitClientType, token, apiUrl);
         // 3. parse configs
         this.logger.debug("Parsing configs..");
+        args.auth = token; // override auth
         const configs = await new pr_configs_parser_1.default().parseAndValidate(args);
         const backportPRs = configs.backportPullRequests;
         // start local git operations
@@ -1380,6 +1374,25 @@ class Runner {
         if (failures.length > 0) {
             throw new Error(`Failure occurred during one of the backports: [${failures.join(" ; ")}]`);
         }
+    }
+    /**
+     * Fetch the GIT token from the provided Args obj, if not empty, otherwise fallback
+     * to the environment variables.
+     * @param args input arguments
+     * @param gitType git client type
+     * @returns the provided or fetched token, or undefined if not set anywhere
+     */
+    fetchToken(args, gitType) {
+        let token = args.auth;
+        if (token === undefined) {
+            // try to fetch the auth from env variable
+            this.logger.info("Auth argument not provided, checking available tokens from env..");
+            token = (0, git_util_1.getGitTokenFromEnv)(gitType);
+            if (!token) {
+                this.logger.info("Git token not found in the environment");
+            }
+        }
+        return token;
     }
     async executeBackport(configs, backportPR, git) {
         this.logger.setContext(backportPR.base);

--- a/src/service/configs/configs-parser.ts
+++ b/src/service/configs/configs-parser.ts
@@ -1,8 +1,7 @@
 import { Args } from "@bp/service/args/args.types";
-import { AuthTokenId, Configs } from "@bp/service/configs/configs.types";
+import { Configs } from "@bp/service/configs/configs.types";
 import LoggerService from "../logger/logger-service";
 import LoggerServiceFactory from "../logger/logger-service-factory";
-import { GitClientType } from "../git/git.types";
 
 /**
  * Abstract configuration parser class in charge to parse 
@@ -34,43 +33,5 @@ import { GitClientType } from "../git/git.types";
     }
 
     return Promise.resolve(configs);
-  }
-
-  /**
-   * Retrieve the git token from env variable, the default is taken from GIT_TOKEN env.
-   * All specific git env variable have precedence and override the default one.
-   * @param gitType 
-   * @returns tuple where 
-   *      - the first element is the corresponding env value
-   *      - the second element is true if the value is not undefined nor empty
-   */
-  public getGitTokenFromEnv(gitType: GitClientType): string | undefined {
-    let [token] = this.getEnv(AuthTokenId.GIT_TOKEN);
-    let [specToken, specOk]: [string | undefined, boolean] = [undefined, false];
-    if (GitClientType.GITHUB == gitType) {
-      [specToken, specOk] = this.getEnv(AuthTokenId.GITHUB_TOKEN);
-    } else if (GitClientType.GITLAB == gitType) {
-      [specToken, specOk] = this.getEnv(AuthTokenId.GITLAB_TOKEN);
-    } else if (GitClientType.CODEBERG == gitType) {
-      [specToken, specOk] = this.getEnv(AuthTokenId.CODEBERG_TOKEN);
-    }
-
-    if (specOk) {
-      token = specToken;
-    }
-
-    return token;
-  }
-
-  /**
-   * Get process env variable given the input key string
-   * @param key 
-   * @returns tuple where 
-   *      - the first element is the corresponding env value
-   *      - the second element is true if the value is not undefined nor empty
-   */
-  public getEnv(key: string): [string | undefined, boolean] {
-    const val = process.env[key];
-    return [val, val !== undefined && val !== ""];
   }
 }

--- a/src/service/configs/pullrequest/pr-configs-parser.ts
+++ b/src/service/configs/pullrequest/pr-configs-parser.ts
@@ -33,19 +33,9 @@ export default class PullRequestConfigsParser extends ConfigsParser {
       throw new Error(`The number of backport branch names, if provided, must match the number of target branches or just one, provided ${bpBranchNames.length} branch names instead`);
     }
 
-    // setup the auth token
-    let token = args.auth;
-    if (token === undefined) {
-      this.logger.info("Auth argument not provided, checking available tokens from env..");
-      token = this.getGitTokenFromEnv(this.gitClient.getClientType());
-      if (!token) {
-        this.logger.info("Git token not set in the env");
-      }
-    }
-
     return {
       dryRun: args.dryRun!,
-      auth: token,
+      auth: args.auth, // this has been already pre-processed before parsing configs
       folder: `${folder.startsWith("/") ? "" : process.cwd() + "/"}${args.folder ?? this.getDefaultFolder()}`,
       mergeStrategy: args.strategy,
       mergeStrategyOption: args.strategyOption,

--- a/src/service/git/git-util.ts
+++ b/src/service/git/git-util.ts
@@ -1,4 +1,5 @@
 import { GitClientType } from "@bp/service/git/git.types";
+import { AuthTokenId } from "@bp/service/configs/configs.types";
 
 const PUBLIC_GITHUB_URL = "https://github.com";
 const PUBLIC_GITHUB_API = "https://api.github.com";
@@ -38,4 +39,42 @@ export const inferGitApiUrl = (prUrl: string, apiVersion = "v4"): string => {
   }
 
   return `${baseUrl}/api/${apiVersion}`;
+};
+
+/**
+ * Retrieve the git token from env variable, the default is taken from GIT_TOKEN env.
+ * All specific git env variable have precedence and override the default one.
+ * @param gitType 
+ * @returns tuple where 
+ *      - the first element is the corresponding env value
+ *      - the second element is true if the value is not undefined nor empty
+ */
+export const getGitTokenFromEnv = (gitType: GitClientType): string | undefined => {
+  let [token] = getEnv(AuthTokenId.GIT_TOKEN);
+  let [specToken, specOk]: [string | undefined, boolean] = [undefined, false];
+  if (GitClientType.GITHUB == gitType) {
+    [specToken, specOk] = getEnv(AuthTokenId.GITHUB_TOKEN);
+  } else if (GitClientType.GITLAB == gitType) {
+    [specToken, specOk] = getEnv(AuthTokenId.GITLAB_TOKEN);
+  } else if (GitClientType.CODEBERG == gitType) {
+    [specToken, specOk] = getEnv(AuthTokenId.CODEBERG_TOKEN);
+  }
+
+  if (specOk) {
+    token = specToken;
+  }
+
+  return token;
+};
+
+/**
+ * Get process env variable given the input key string
+ * @param key 
+ * @returns tuple where 
+ *      - the first element is the corresponding env value
+ *      - the second element is true if the value is not undefined nor empty
+ */
+export const getEnv = (key: string): [string | undefined, boolean] => {
+  const val = process.env[key];
+  return [val, val !== undefined && val !== ""];
 };

--- a/test/service/configs/pullrequest/github-pr-configs-parser-multiple.test.ts
+++ b/test/service/configs/pullrequest/github-pr-configs-parser-multiple.test.ts
@@ -4,7 +4,7 @@ import PullRequestConfigsParser from "@bp/service/configs/pullrequest/pr-configs
 import GitClientFactory from "@bp/service/git/git-client-factory";
 import { GitClientType } from "@bp/service/git/git.types";
 import { mockGitHubClient } from "../../../support/mock/git-client-mock-support";
-import { resetEnvTokens, resetProcessArgs } from "../../../support/utils";
+import { resetProcessArgs } from "../../../support/utils";
 import { MERGED_PR_FIXTURE, REPO, TARGET_OWNER, MULT_COMMITS_PR_FIXTURE } from "../../../support/mock/github-data";
 import GitHubMapper from "@bp/service/git/github/github-mapper";
 import GitHubClient from "@bp/service/git/github/github-client";
@@ -27,9 +27,6 @@ describe("github pull request config parser", () => {
   beforeEach(() => {
     // reset process.env variables
     resetProcessArgs();
-
-    // reset env tokens
-    resetEnvTokens();
     
     // mock octokit
     mockGitHubClient("http://localhost/api/v3");

--- a/test/service/configs/pullrequest/github-pr-configs-parser.test.ts
+++ b/test/service/configs/pullrequest/github-pr-configs-parser.test.ts
@@ -1,10 +1,10 @@
 import { Args } from "@bp/service/args/args.types";
-import { AuthTokenId, Configs } from "@bp/service/configs/configs.types";
+import { Configs } from "@bp/service/configs/configs.types";
 import PullRequestConfigsParser from "@bp/service/configs/pullrequest/pr-configs-parser";
 import GitClientFactory from "@bp/service/git/git-client-factory";
 import { GitClientType } from "@bp/service/git/git.types";
 import { mockGitHubClient } from "../../../support/mock/git-client-mock-support";
-import { addProcessArgs, createTestFile, removeTestFile, resetEnvTokens, resetProcessArgs } from "../../../support/utils";
+import { addProcessArgs, createTestFile, removeTestFile, resetProcessArgs } from "../../../support/utils";
 import { MERGED_PR_FIXTURE, OPEN_PR_FIXTURE, NOT_MERGED_PR_FIXTURE, REPO, TARGET_OWNER, MULT_COMMITS_PR_FIXTURE } from "../../../support/mock/github-data";
 import CLIArgsParser from "@bp/service/args/cli/cli-args-parser";
 import GitHubMapper from "@bp/service/git/github/github-mapper";
@@ -65,9 +65,6 @@ describe("github pull request config parser", () => {
   beforeEach(() => {
     // reset process.env variables
     resetProcessArgs();
-
-    // reset env tokens
-    resetEnvTokens();
 
     // mock octokit
     mockGitHubClient("http://localhost/api/v3");
@@ -840,84 +837,6 @@ describe("github pull request config parser", () => {
       assignees: ["user3", "user4"],
       labels: [],
       comments: ["First comment", "Second comment"],
-    });
-  });
-
-  test("override token using auth arg", async () => {
-    process.env[AuthTokenId.GITHUB_TOKEN] = "mygithubtoken";
-    const args: Args = {
-      dryRun: true,
-      auth: "whatever",
-      pullRequest: mergedPRUrl,
-      targetBranch: "prod",
-      folder: "/tmp/test",
-      gitUser: "GitHub",
-      gitEmail: "noreply@github.com",
-      reviewers: [],
-      assignees: [],
-      inheritReviewers: true,
-    };
-
-    const configs: Configs = await configParser.parseAndValidate(args);
-
-    expect(configs.dryRun).toEqual(true);
-    expect(configs.auth).toEqual("whatever");
-    expect(configs.folder).toEqual("/tmp/test");
-    expect(configs.git).toEqual({
-      user: "GitHub",
-      email: "noreply@github.com"
-    });
-  });
-
-  test("auth using GITHUB_TOKEN has precedence over GIT_TOKEN env variable", async () => {
-    process.env[AuthTokenId.GIT_TOKEN] = "mygittoken";
-    process.env[AuthTokenId.GITHUB_TOKEN] = "mygithubtoken";
-    const args: Args = {
-      dryRun: true,
-      pullRequest: mergedPRUrl,
-      targetBranch: "prod",
-      folder: "/tmp/test",
-      gitUser: "GitHub",
-      gitEmail: "noreply@github.com",
-      reviewers: [],
-      assignees: [],
-      inheritReviewers: true,
-    };
-
-    const configs: Configs = await configParser.parseAndValidate(args);
-
-    expect(configs.dryRun).toEqual(true);
-    expect(configs.auth).toEqual("mygithubtoken");
-    expect(configs.folder).toEqual("/tmp/test");
-    expect(configs.git).toEqual({
-      user: "GitHub",
-      email: "noreply@github.com"
-    });
-  });
-
-  test("ignore env variables related to other git platforms", async () => {
-    process.env[AuthTokenId.GITLAB_TOKEN] = "mygitlabtoken";
-    process.env[AuthTokenId.CODEBERG_TOKEN] = "mycodebergtoken";
-    const args: Args = {
-      dryRun: true,
-      pullRequest: mergedPRUrl,
-      targetBranch: "prod",
-      folder: "/tmp/test",
-      gitUser: "GitHub",
-      gitEmail: "noreply@github.com",
-      reviewers: [],
-      assignees: [],
-      inheritReviewers: true,
-    };
-
-    const configs: Configs = await configParser.parseAndValidate(args);
-
-    expect(configs.dryRun).toEqual(true);
-    expect(configs.auth).toEqual(undefined);
-    expect(configs.folder).toEqual("/tmp/test");
-    expect(configs.git).toEqual({
-      user: "GitHub",
-      email: "noreply@github.com"
     });
   });
 });

--- a/test/service/configs/pullrequest/gitlab-pr-configs-parser-multiple.test.ts
+++ b/test/service/configs/pullrequest/gitlab-pr-configs-parser-multiple.test.ts
@@ -7,7 +7,6 @@ import { getAxiosMocked } from "../../../support/mock/git-client-mock-support";
 import { MERGED_SQUASHED_MR } from "../../../support/mock/gitlab-data";
 import GitLabClient from "@bp/service/git/gitlab/gitlab-client";
 import GitLabMapper from "@bp/service/git/gitlab/gitlab-mapper";
-import { resetEnvTokens } from "../../../support/utils";
 
 jest.spyOn(GitLabMapper.prototype, "mapPullRequest");
 jest.spyOn(GitLabClient.prototype, "getPullRequest");
@@ -32,9 +31,6 @@ describe("gitlab merge request config parser", () => {
   });
 
   beforeEach(() => {
-    // reset env tokens
-    resetEnvTokens();
-
     configParser = new PullRequestConfigsParser();
   });
 

--- a/test/service/configs/pullrequest/gitlab-pr-configs-parser.test.ts
+++ b/test/service/configs/pullrequest/gitlab-pr-configs-parser.test.ts
@@ -1,5 +1,5 @@
 import { Args } from "@bp/service/args/args.types";
-import { AuthTokenId, Configs } from "@bp/service/configs/configs.types";
+import { Configs } from "@bp/service/configs/configs.types";
 import PullRequestConfigsParser from "@bp/service/configs/pullrequest/pr-configs-parser";
 import GitClientFactory from "@bp/service/git/git-client-factory";
 import { GitClientType } from "@bp/service/git/git.types";
@@ -796,99 +796,6 @@ describe("gitlab merge request config parser", () => {
       assignees: ["user3", "user4"],
       labels: [],
       comments: ["First comment", "Second comment"],
-    });
-  });
-
-  test("override token using auth arg", async () => {
-    process.env[AuthTokenId.GITLAB_TOKEN] = "mygitlabtoken";
-    const args: Args = {
-      dryRun: true,
-      auth: "whatever",
-      pullRequest: mergedPRUrl,
-      targetBranch: "prod",
-      folder: "/tmp/test",
-      gitUser: "Gitlab",
-      gitEmail: "noreply@gitlab.com",
-      reviewers: [],
-      assignees: [],
-      inheritReviewers: true,
-    };
-
-    const configs: Configs = await configParser.parseAndValidate(args);
-
-    expect(GitLabClient.prototype.getPullRequest).toBeCalledTimes(1);
-    expect(GitLabClient.prototype.getPullRequest).toBeCalledWith("superuser", "backporting-example", 1, true);
-    expect(GitLabMapper.prototype.mapPullRequest).toBeCalledTimes(1);
-    expect(GitLabMapper.prototype.mapPullRequest).toBeCalledWith(expect.anything(), []);
-
-    expect(configs.dryRun).toEqual(true);
-    expect(configs.auth).toEqual("whatever");
-    expect(configs.folder).toEqual("/tmp/test");
-    expect(configs.git).toEqual({
-      user: "Gitlab",
-      email: "noreply@gitlab.com"
-    });
-  });
-
-  test("auth using GITLAB_TOKEN has precedence over GIT_TOKEN env variable", async () => {
-    process.env[AuthTokenId.GIT_TOKEN] = "mygittoken";
-    process.env[AuthTokenId.GITLAB_TOKEN] = "mygitlabtoken";
-    const args: Args = {
-      dryRun: true,
-      pullRequest: mergedPRUrl,
-      targetBranch: "prod",
-      folder: "/tmp/test",
-      gitUser: "Gitlab",
-      gitEmail: "noreply@gitlab.com",
-      reviewers: [],
-      assignees: [],
-      inheritReviewers: true,
-    };
-
-    const configs: Configs = await configParser.parseAndValidate(args);
-
-    expect(GitLabClient.prototype.getPullRequest).toBeCalledTimes(1);
-    expect(GitLabClient.prototype.getPullRequest).toBeCalledWith("superuser", "backporting-example", 1, true);
-    expect(GitLabMapper.prototype.mapPullRequest).toBeCalledTimes(1);
-    expect(GitLabMapper.prototype.mapPullRequest).toBeCalledWith(expect.anything(), []);
-
-    expect(configs.dryRun).toEqual(true);
-    expect(configs.auth).toEqual("mygitlabtoken");
-    expect(configs.folder).toEqual("/tmp/test");
-    expect(configs.git).toEqual({
-      user: "Gitlab",
-      email: "noreply@gitlab.com"
-    });
-  });
-  
-  test("ignore env variables related to other git platforms", async () => {
-    process.env[AuthTokenId.CODEBERG_TOKEN] = "mycodebergtoken";
-    process.env[AuthTokenId.GITHUB_TOKEN] = "mygithubtoken";
-    const args: Args = {
-      dryRun: true,
-      pullRequest: mergedPRUrl,
-      targetBranch: "prod",
-      folder: "/tmp/test",
-      gitUser: "Gitlab",
-      gitEmail: "noreply@gitlab.com",
-      reviewers: [],
-      assignees: [],
-      inheritReviewers: true,
-    };
-
-    const configs: Configs = await configParser.parseAndValidate(args);
-
-    expect(GitLabClient.prototype.getPullRequest).toBeCalledTimes(1);
-    expect(GitLabClient.prototype.getPullRequest).toBeCalledWith("superuser", "backporting-example", 1, true);
-    expect(GitLabMapper.prototype.mapPullRequest).toBeCalledTimes(1);
-    expect(GitLabMapper.prototype.mapPullRequest).toBeCalledWith(expect.anything(), []);
-
-    expect(configs.dryRun).toEqual(true);
-    expect(configs.auth).toEqual(undefined);
-    expect(configs.folder).toEqual("/tmp/test");
-    expect(configs.git).toEqual({
-      user: "Gitlab",
-      email: "noreply@gitlab.com"
     });
   });
 });

--- a/test/service/runner/gha-github-runner.test.ts
+++ b/test/service/runner/gha-github-runner.test.ts
@@ -3,7 +3,7 @@ import Runner from "@bp/service/runner/runner";
 import GitCLIService from "@bp/service/git/git-cli";
 import GitHubClient from "@bp/service/git/github/github-client";
 import GHAArgsParser from "@bp/service/args/gha/gha-args-parser";
-import { createTestFile, removeTestFile, spyGetInput } from "../../support/utils";
+import { createTestFile, removeTestFile, resetEnvTokens, spyGetInput } from "../../support/utils";
 import { mockGitHubClient } from "../../support/mock/git-client-mock-support";
 import GitClientFactory from "@bp/service/git/git-client-factory";
 import { GitClientType } from "@bp/service/git/git.types";
@@ -46,6 +46,9 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  // reset git env tokens
+  resetEnvTokens();
+  
   mockGitHubClient();
 
   // create GHA arguments parser

--- a/test/service/runner/gha-gitlab-runner.test.ts
+++ b/test/service/runner/gha-gitlab-runner.test.ts
@@ -3,7 +3,7 @@ import Runner from "@bp/service/runner/runner";
 import GitCLIService from "@bp/service/git/git-cli";
 import GitLabClient from "@bp/service/git/gitlab/gitlab-client";
 import GHAArgsParser from "@bp/service/args/gha/gha-args-parser";
-import { createTestFile, removeTestFile, spyGetInput } from "../../support/utils";
+import { createTestFile, removeTestFile, resetEnvTokens, spyGetInput } from "../../support/utils";
 import { getAxiosMocked } from "../../support/mock/git-client-mock-support";
 import { MERGED_SQUASHED_MR } from "../../support/mock/gitlab-data";
 import GitClientFactory from "@bp/service/git/git-client-factory";
@@ -59,6 +59,9 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  // reset git env tokens
+  resetEnvTokens();
+  
   // create GHA arguments parser
   parser = new GHAArgsParser();
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

fixes https://github.com/kiegroup/git-backporting/issues/96

### Description

Fix when Git tokens are parsed/fetched from the envrionment variables:
* Moved the logic before the `GitClient` creation, inside the `runner`.
* Now the `PullRequestConfigsParser.parseAndValidate()` assumes the `args.auth` has already the proper token setup.

### Checklist
- [x] Tests added if applicable.
- [ ] Documentation updated if applicable.

> **Note:** `dist/cli/index.js` and `dist/gha/index.js` are automatically generated by git hooks and gh workflows.

<details>
<summary>
First time here?
</summary>

This project follows [git conventional commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) pattern, therefore the commits should have the following format:

```
<type>(<optional scope>): <subject>
empty separator line
<optional body>
empty separator line
<optional footer>
```

Where the type must be one of `[build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]`

> **NOTE**: if you are still in a `work in progress` branch and you want to push your changes remotely, consider adding `--no-verify` for both `commit` and `push`, e.g., `git push origin <feat-branch> --no-verify` - this could become useful to push changes where there are still tests failures. Once the pull request is ready, please `amend` the commit and force-push it to keep following the adopted git commit standard. 

</details>

<details>
<summary>
How to prepare for a new release?
</summary>

There is no need to manually update `package.json` version and `CHANGELOG.md` information. This process has been automated in [Prepare Release](./workflows/prepare-release.yml) *Github* workflow.

Therefore whenever enough changes are merged into the `main` branch, one of the maintainers will trigger this workflow that will automatically update `version` and `changelog` based on the commits on the git tree.

More details can be found in [package release](https://github.com/kiegroup/git-backporting/blob/main/README.md#package-release) section of the README.
</details>