### PR TITLE
build: upgrade to node20 for gha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     name: ${{ matrix.os }} - node ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [16, 18, 20]
         os: [ubuntu-latest]
-      fail-fast: true
+      fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
     name: ${{ matrix.os }} - node ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [16, 18, 20]
         os: [ubuntu-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
     required: false
 
 runs:
-  using: node16
+  using: node20
   main: dist/gha/index.js
 
 branding:


### PR DESCRIPTION
**Thank you for submitting this pull request**

Fixes the following Warning:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: kiegroup/git-backporting@v4.5.1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

## Description
<!--- Describe your changes in detail -->

Upgrade the GHA node version to `20`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI workflows now run on three different node versions: `16`, `18` and `20`.

### Checklist
- [ ] Tests added if applicable.
- [ ] Documentation updated if applicable.

### Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them _after approval_ or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

> **Note:** `dist/cli/index.js` and `dist/gha/index.js` are automatically generated by git hooks and gh workflows.

<details>
<summary>
First time here?
</summary>

This project follows [git conventional commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) pattern, therefore the commits should have the following format:

```
<type>(<optional scope>): <subject>
empty separator line
<optional body>
empty separator line
<optional footer>
```

Where the type must be one of `[build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]`

> **NOTE**: if you are still in a `work in progress` branch and you want to push your changes remotely, consider adding `--no-verify` for both `commit` and `push`, e.g., `git push origin <feat-branch> --no-verify` - this could become useful to push changes where there are still tests failures. Once the pull request is ready, please `amend` the commit and force-push it to keep following the adopted git commit standard. 

</details>

<details>
<summary>
How to prepare for a new release?
</summary>

There is no need to manually update `package.json` version and `CHANGELOG.md` information. This process has been automated in [Prepare Release](./workflows/prepare-release.yml) *Github* workflow.

Therefore whenever enough changes are merged into the `main` branch, one of the maintainers will trigger this workflow that will automatically update `version` and `changelog` based on the commits on the git tree.

More details can be found in [package release](https://github.com/kiegroup/git-backporting/blob/main/README.md#package-release) section of the README.
</details>