### PR TITLE
fix: cherry-pick multiple commits in the correct order

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -1469,7 +1469,7 @@ class Runner {
         }
         // 7. apply all changes to the new branch
         this.logger.debug("Cherry picking commits..");
-        for (const sha of originalPR.commits) {
+        for (const sha of originalPR.commits.reverse()) {
             await git.gitCli.cherryPick(configs.folder, sha, configs.mergeStrategy, configs.mergeStrategyOption, configs.cherryPickOptions);
         }
         if (!configs.dryRun) {

--- a/dist/gha/index.js
+++ b/dist/gha/index.js
@@ -1436,7 +1436,7 @@ class Runner {
         }
         // 7. apply all changes to the new branch
         this.logger.debug("Cherry picking commits..");
-        for (const sha of originalPR.commits) {
+        for (const sha of originalPR.commits.reverse()) {
             await git.gitCli.cherryPick(configs.folder, sha, configs.mergeStrategy, configs.mergeStrategyOption, configs.cherryPickOptions);
         }
         if (!configs.dryRun) {

--- a/src/service/runner/runner.ts
+++ b/src/service/runner/runner.ts
@@ -146,7 +146,7 @@ export default class Runner {
 
     // 7. apply all changes to the new branch
     this.logger.debug("Cherry picking commits..");
-    for (const sha of originalPR.commits!) {
+    for (const sha of originalPR.commits.reverse()!) {
       await git.gitCli.cherryPick(configs.folder, sha, configs.mergeStrategy, configs.mergeStrategyOption, configs.cherryPickOptions);
     }
 

--- a/test/service/runner/cli-github-runner.test.ts
+++ b/test/service/runner/cli-github-runner.test.ts
@@ -681,7 +681,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
     expect(GitCLIService.prototype.cherryPick).toBeCalledTimes(2);
-    expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "0404fb922ab75c3a8aecad5c97d9af388df04695", undefined, undefined, undefined);
+    expect(GitCLIService.prototype.cherryPick).toHaveBeenLastCalledWith(cwd, "0404fb922ab75c3a8aecad5c97d9af388df04695", undefined, undefined, undefined);
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "11da4e38aa3e577ffde6d546f1c52e53b04d3151", undefined, undefined, undefined);
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
@@ -787,7 +787,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
     expect(GitCLIService.prototype.cherryPick).toBeCalledTimes(2);
-    expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "0404fb922ab75c3a8aecad5c97d9af388df04695", "ort", "find-renames", undefined);
+    expect(GitCLIService.prototype.cherryPick).toHaveBeenLastCalledWith(cwd, "0404fb922ab75c3a8aecad5c97d9af388df04695", "ort", "find-renames", undefined);
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "11da4e38aa3e577ffde6d546f1c52e53b04d3151", "ort", "find-renames", undefined);
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);

--- a/test/service/runner/gha-github-runner.test.ts
+++ b/test/service/runner/gha-github-runner.test.ts
@@ -498,7 +498,7 @@ describe("gha runner", () => {
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
     expect(GitCLIService.prototype.cherryPick).toBeCalledTimes(2);
-    expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "0404fb922ab75c3a8aecad5c97d9af388df04695", undefined, undefined, undefined);
+    expect(GitCLIService.prototype.cherryPick).toHaveBeenLastCalledWith(cwd, "0404fb922ab75c3a8aecad5c97d9af388df04695", undefined, undefined, undefined);
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "11da4e38aa3e577ffde6d546f1c52e53b04d3151", undefined, undefined, undefined);
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);


### PR DESCRIPTION
Fixes: https://github.com/kiegroup/git-backporting/issues/114
