### PR TITLE
WIP: feat: comment on the original pull/merge request when on error

### DIFF
--- a/src/service/git/git-client.ts
+++ b/src/service/git/git-client.ts
@@ -38,6 +38,11 @@ import { BackportPullRequest, GitClientType, GitPullRequest } from "@bp/service/
   // WRITE
 
   /**
+   * Add a comment about a failed backport.
+   */
+   commentError(prUrl: string, message: string): Promise<void>;
+
+  /**
    * Create a new pull request on the underneath git service
    * @param backport backport pull request data
    * @returns {Promise<string>} the pull request url

--- a/src/service/git/github/github-client.ts
+++ b/src/service/git/github/github-client.ts
@@ -141,6 +141,16 @@ export default class GitHubClient implements GitClient {
     return data.html_url;
   }
 
+  async commentError(prUrl: string, message: string): Promise<void> {
+    const { owner, project, id } = this.extractPullRequestData(prUrl);
+    await this.octokit.rest.issues.createComment({
+      owner: owner,
+      repo: repo,
+      issue_number: id,
+      body: message,
+    });
+  }
+
   // UTILS
 
   /**

--- a/src/service/runner/runner.ts
+++ b/src/service/runner/runner.ts
@@ -91,7 +91,11 @@ export default class Runner {
           gitCli: git,
         });
       } catch(error) {
-        this.logger.error(`Something went wrong backporting to ${pr.base}: ${error}`);
+	const error = `Something went wrong backporting to ${pr.base}: ${error}`;
+	if (!args.dryRun) {
+	  gitApi.commentError(configs.originalPullRequest.url, error)
+	}
+        this.logger.error(error);
         failures.push(error as string);
       }
     }


### PR DESCRIPTION
A comment is added to the original PR when a backport fails. The developers watching the PR will be notified even if they are not watching the CI.

Fixes: https://github.com/kiegroup/git-backporting/issues/123
