### PR TITLE
fix: cherry-pick order on GitLab by reversing commmit list only once

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -884,6 +884,11 @@ class GitHubClient {
                     pull_number: prNumber,
                 });
                 commits.push(...data.map(c => c.sha));
+                if (this.isForCodeberg) {
+                    // For some reason, even though Codeberg advertises API compatibility
+                    // with GitHub, it returns commits in reversed order.
+                    commits.reverse();
+                }
             }
             catch (error) {
                 throw new Error(`Failed to retrieve commits for pull request n. ${prNumber}`);
@@ -1619,14 +1624,6 @@ class Runner {
         }
         // 7. apply all changes to the new branch
         this.logger.debug("Cherry picking commits..");
-        // Commits might be ordered in different ways based on the git service, e.g., considering top to bottom
-        // GITHUB   --> oldest to newest
-        // CODEBERG --> newest to oldest
-        // GITLAB   --> newest to oldest
-        if (git.gitClientType === git_types_1.GitClientType.CODEBERG || git.gitClientType === git_types_1.GitClientType.GITLAB) {
-            // reverse the order as we always need to process from older to newest
-            originalPR.commits.reverse();
-        }
         for (const sha of originalPR.commits) {
             await git.gitCli.cherryPick(configs.folder, sha, configs.mergeStrategy, configs.mergeStrategyOption, configs.cherryPickOptions);
         }

--- a/dist/gha/index.js
+++ b/dist/gha/index.js
@@ -849,6 +849,11 @@ class GitHubClient {
                     pull_number: prNumber,
                 });
                 commits.push(...data.map(c => c.sha));
+                if (this.isForCodeberg) {
+                    // For some reason, even though Codeberg advertises API compatibility
+                    // with GitHub, it returns commits in reversed order.
+                    commits.reverse();
+                }
             }
             catch (error) {
                 throw new Error(`Failed to retrieve commits for pull request n. ${prNumber}`);
@@ -1584,14 +1589,6 @@ class Runner {
         }
         // 7. apply all changes to the new branch
         this.logger.debug("Cherry picking commits..");
-        // Commits might be ordered in different ways based on the git service, e.g., considering top to bottom
-        // GITHUB   --> oldest to newest
-        // CODEBERG --> newest to oldest
-        // GITLAB   --> newest to oldest
-        if (git.gitClientType === git_types_1.GitClientType.CODEBERG || git.gitClientType === git_types_1.GitClientType.GITLAB) {
-            // reverse the order as we always need to process from older to newest
-            originalPR.commits.reverse();
-        }
         for (const sha of originalPR.commits) {
             await git.gitCli.cherryPick(configs.folder, sha, configs.mergeStrategy, configs.mergeStrategyOption, configs.cherryPickOptions);
         }

--- a/src/service/git/github/github-client.ts
+++ b/src/service/git/github/github-client.ts
@@ -73,6 +73,11 @@ export default class GitHubClient implements GitClient {
         });
 
         commits.push(...data.map(c => c.sha));
+        if (this.isForCodeberg) {
+          // For some reason, even though Codeberg advertises API compatibility
+          // with GitHub, it returns commits in reversed order.
+          commits.reverse();
+        }
       } catch(error) {
         throw new Error(`Failed to retrieve commits for pull request n. ${prNumber}`);
       }

--- a/src/service/runner/runner.ts
+++ b/src/service/runner/runner.ts
@@ -152,14 +152,6 @@ export default class Runner {
 
     // 7. apply all changes to the new branch
     this.logger.debug("Cherry picking commits..");
-    // Commits might be ordered in different ways based on the git service, e.g., considering top to bottom
-    // GITHUB   --> oldest to newest
-    // CODEBERG --> newest to oldest
-    // GITLAB   --> newest to oldest
-    if (git.gitClientType === GitClientType.CODEBERG || git.gitClientType === GitClientType.GITLAB) {
-      // reverse the order as we always need to process from older to newest
-      originalPR.commits.reverse();
-    }
     for (const sha of originalPR.commits) {
       await git.gitCli.cherryPick(configs.folder, sha, configs.mergeStrategy, configs.mergeStrategyOption, configs.cherryPickOptions);
     }

--- a/test/service/runner/cli-codeberg-runner.test.ts
+++ b/test/service/runner/cli-codeberg-runner.test.ts
@@ -370,7 +370,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://codeberg.org/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-0404fb9-11da4e3");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-11da4e3-0404fb9");
 
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(1);
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "pull/4444/head:pr/4444");
@@ -380,13 +380,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "11da4e38aa3e577ffde6d546f1c52e53b04d3151", undefined, undefined, undefined);
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-0404fb9-11da4e3");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-11da4e3-0404fb9");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
 	owner: "owner",
 	repo: "reponame",
-	head: "bp-target-0404fb9-11da4e3",
+	head: "bp-target-11da4e3-0404fb9",
 	base: "target",
 	title: "[target] PR Title",
 	body: "**Backport:** https://codeberg.org/owner/reponame/pulls/4444\r\n\r\nPlease review and merge",
@@ -728,7 +728,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://codeberg.org/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-0404fb9-11da4e3");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-11da4e3-0404fb9");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
@@ -737,13 +737,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "11da4e38aa3e577ffde6d546f1c52e53b04d3151", undefined, undefined, undefined);
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-0404fb9-11da4e3");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-11da4e3-0404fb9");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-0404fb9-11da4e3", 
+        head: "bp-target-11da4e3-0404fb9", 
         base: "target", 
         title: "[target] PR Title", 
         body: "**Backport:** https://codeberg.org/owner/reponame/pulls/8632\r\n\r\nPlease review and merge",
@@ -834,7 +834,7 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.clone).toBeCalledWith("https://codeberg.org/owner/reponame.git", cwd, "target");
 
     expect(GitCLIService.prototype.createLocalBranch).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-0404fb9-11da4e3");
+    expect(GitCLIService.prototype.createLocalBranch).toBeCalledWith(cwd, "bp-target-11da4e3-0404fb9");
     
     expect(GitCLIService.prototype.fetch).toBeCalledTimes(0);
 
@@ -843,13 +843,13 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "11da4e38aa3e577ffde6d546f1c52e53b04d3151", "ort", "find-renames", undefined);
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
-    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-0404fb9-11da4e3");
+    expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-11da4e3-0404fb9");
 
     expect(GitHubClient.prototype.createPullRequest).toBeCalledTimes(1);
     expect(GitHubClient.prototype.createPullRequest).toBeCalledWith({
         owner: "owner", 
         repo: "reponame", 
-        head: "bp-target-0404fb9-11da4e3", 
+        head: "bp-target-11da4e3-0404fb9", 
         base: "target", 
         title: "[target] PR Title", 
         body: "**Backport:** https://codeberg.org/owner/reponame/pulls/8632\r\n\r\nPlease review and merge",

--- a/test/service/runner/cli-gitlab-runner.test.ts
+++ b/test/service/runner/cli-gitlab-runner.test.ts
@@ -582,8 +582,8 @@ describe("cli runner", () => {
     expect(GitCLIService.prototype.fetch).toBeCalledWith(cwd, "merge-requests/2/head:pr/2");
 
     expect(GitCLIService.prototype.cherryPick).toBeCalledTimes(2);
-    expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "e4dd336a4a20f394df6665994df382fb1d193a11", undefined, undefined, undefined);
-    expect(GitCLIService.prototype.cherryPick).toBeCalledWith(cwd, "974519f65c9e0ed65277cd71026657a09fca05e7", undefined, undefined, undefined);
+    expect(GitCLIService.prototype.cherryPick).toHaveBeenNthCalledWith(1, cwd, "e4dd336a4a20f394df6665994df382fb1d193a11", undefined, undefined, undefined);
+    expect(GitCLIService.prototype.cherryPick).toHaveBeenNthCalledWith(2, cwd, "974519f65c9e0ed65277cd71026657a09fca05e7", undefined, undefined, undefined);
 
     expect(GitCLIService.prototype.push).toBeCalledTimes(1);
     expect(GitCLIService.prototype.push).toBeCalledWith(cwd, "bp-target-e4dd336-974519f");


### PR DESCRIPTION
**Thank you for submitting this pull request**

## Description
<!--- Describe your changes in detail -->
GitLabClient already handle commit order reversing, so re-handle it in Runner causes cherry-pick order on GitLab to be wrong.

Remove commit order handling from Runner, and instead handle difference between GitHub and Codeberg inside GitHubClient.

Now, since the default of --bp-branch-name takes the commit list from {GitHub,GitLab}Client directly, that means backporting branch name on Codeberg will also be changed to have commits in the correct order too (old to new, in line with GitHub and GitLab), which is IMO a nice bonus.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit test for GitLab is made more strict.
- Dry-run test with GitHub:
```
$ node dist/cli/index.js -pr https://github.com/lampajr/backporting-example/pull/111 --no-squash -tb develop -d
[WARN ] Dry run enabled
[INFO ] Auth argument not provided, checking available tokens from env..
[DEBUG] Setting up github client: apiUrl=https://api.github.com, token=****
[DEBUG] Parsing configs..
[DEBUG] Fetching pull request lampajr/backporting-example/111
[DEBUG] [develop] Cloning repo..
[INFO ] [develop] Cloning repository https://github.com/lampajr/backporting-example.git to /workspaces/git-backporting/bp
[DEBUG] [develop] Creating local branch..
[INFO ] [develop] Creating branch bp-develop-55eb00f-518e65c
[DEBUG] [develop] Cherry picking commits..
[INFO ] [develop] Cherry picking 55eb00fc71e09cfba968a27222dafb25aef2c53c
[DEBUG] [develop] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,55eb00fc71e09cfba968a27222dafb25aef2c53c
[INFO ] [develop] Cherry picking 518e65ce28e876fbc8bdf34783fcb440c45c922a
[DEBUG] [develop] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,518e65ce28e876fbc8bdf34783fcb440c45c922a
[WARN ] [develop] Pull request creation and remote push skipped
[INFO ] [develop] {
  "owner": "lampajr",
  "repo": "backporting-example",
  "head": "bp-develop-55eb00f-518e65c",
  "base": "develop",
  "title": "[develop] Test multiple commits",
  "body": "**Backport:** https://github.com/lampajr/backporting-example/pull/111\r\n\r\n",
  "reviewers": [
    "lampajr"
  ],
  "assignees": [],
  "labels": [],
  "comments": []
}
[INFO ] Process succeeded
```
- Dry-run test with Codeberg (together with #136 as otherwise it simply crash):
```
$ node dist/cli/index.js -pr https://codeberg.org/forgejo/forgejo/pulls/2669 --no-squash -tb "v8.0/forgejo" -d
[WARN ] Dry run enabled
[INFO ] Auth argument not provided, checking available tokens from env..
[INFO ] Git token not found in the environment
[DEBUG] Setting up codeberg client: apiUrl=https://codeberg.org/api/v1, token=****
[DEBUG] Parsing configs..
[DEBUG] Fetching pull request forgejo/forgejo/2669
[DEBUG] [v8.0/forgejo] Cloning repo..
[INFO ] [v8.0/forgejo] Cloning repository https://codeberg.org/forgejo/forgejo.git to /workspaces/git-backporting/bp
[DEBUG] [v8.0/forgejo] Creating local branch..
[INFO ] [v8.0/forgejo] Creating branch bp-v8.0/forgejo-1d32408-781a37f-8309f00-fae8d9f-6721cba-562e5cd-d789d33-8218e80-10bca45-db6f628-ed8e8a7-d6428f9-069d87b-2b6546a-4c7cb0a-7e0014d-16a8658-6e98bac
[DEBUG] [v8.0/forgejo] Fetching pull request remote..
[INFO ] [v8.0/forgejo] Fetching origin pull/2669/head:pr/2669
[DEBUG] [v8.0/forgejo] Cherry picking commits..
[INFO ] [v8.0/forgejo] Cherry picking 1d3240887c519a04c13bcd7e852c6d6ad1cb00b5
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,1d3240887c519a04c13bcd7e852c6d6ad1cb00b5
[INFO ] [v8.0/forgejo] Cherry picking 781a37fbe18c223763f51968862f1c8f61e7e260
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,781a37fbe18c223763f51968862f1c8f61e7e260
[INFO ] [v8.0/forgejo] Cherry picking 8309f008c2721e313e1949ce42ed410e844c16e7
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,8309f008c2721e313e1949ce42ed410e844c16e7
[INFO ] [v8.0/forgejo] Cherry picking fae8d9f70d31704af91cbf37bcefcc4772830695
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,fae8d9f70d31704af91cbf37bcefcc4772830695
[INFO ] [v8.0/forgejo] Cherry picking 6721cba75b4997448b618a4b00ef25f142924de0
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,6721cba75b4997448b618a4b00ef25f142924de0
[INFO ] [v8.0/forgejo] Cherry picking 562e5cdf324597882b7e6971be1b9a148bbc7839
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,562e5cdf324597882b7e6971be1b9a148bbc7839
[INFO ] [v8.0/forgejo] Cherry picking d789d33229b3998bb33f1505d122504c8039f23d
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,d789d33229b3998bb33f1505d122504c8039f23d
[INFO ] [v8.0/forgejo] Cherry picking 8218e80bfc3a1f9ba02ce60f1acafdc0e57c5ae0
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,8218e80bfc3a1f9ba02ce60f1acafdc0e57c5ae0
[INFO ] [v8.0/forgejo] Cherry picking 10bca456a9140519e95559aa7bac2221e1156c5b
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,10bca456a9140519e95559aa7bac2221e1156c5b
[INFO ] [v8.0/forgejo] Cherry picking db6f6281fcf568ae8e35330a4a93c9be1cb46efd
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,db6f6281fcf568ae8e35330a4a93c9be1cb46efd
[INFO ] [v8.0/forgejo] Cherry picking ed8e8a792e75b930074cd3cf1bab580a09ff8485
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,ed8e8a792e75b930074cd3cf1bab580a09ff8485
[INFO ] [v8.0/forgejo] Cherry picking d6428f92ce7ce67d127cbd5bb4977aa92abf071c
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,d6428f92ce7ce67d127cbd5bb4977aa92abf071c
[INFO ] [v8.0/forgejo] Cherry picking 069d87b80f909e91626249afbb240a1df339a8fd
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,069d87b80f909e91626249afbb240a1df339a8fd
[INFO ] [v8.0/forgejo] Cherry picking 2b6546adc954d450a9c6befccd407ce2ca1636a0
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,2b6546adc954d450a9c6befccd407ce2ca1636a0
[INFO ] [v8.0/forgejo] Cherry picking 4c7cb0a5d20e8973b03e35d91119cf917eed125e
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,4c7cb0a5d20e8973b03e35d91119cf917eed125e
[INFO ] [v8.0/forgejo] Cherry picking 7e0014dd1391e123d95f2537c3b2165fef7122ef
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,7e0014dd1391e123d95f2537c3b2165fef7122ef
[INFO ] [v8.0/forgejo] Cherry picking 16a8658878a2656cb131453b728b65a89271f11f
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,16a8658878a2656cb131453b728b65a89271f11f
[INFO ] [v8.0/forgejo] Cherry picking 6e98bacbbd3c089b2ccfa725c58184f4dfe5e7fe
[DEBUG] [v8.0/forgejo] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,6e98bacbbd3c089b2ccfa725c58184f4dfe5e7fe
[WARN ] [v8.0/forgejo] Pull request creation and remote push skipped
[INFO ] [v8.0/forgejo] {
  "owner": "forgejo",
  "repo": "forgejo",
  "head": "bp-v8.0/forgejo-1d32408-781a37f-8309f00-fae8d9f-6721cba-562e5cd-d789d33-8218e80-10bca45-db6f628-ed8e8a7-d6428f9-069d87b-2b6546a-4c7cb0a-7e0014d-16a8658-6e98bac",
  "base": "v8.0/forgejo",
  "title": "[v8.0/forgejo] Render inline file permalinks",
  "body": "**Backport:** https://codeberg.org/forgejo/forgejo/pulls/2669\r\n\r\nCloses #2666\r\n\r\nPreview of the changed rendering:\r\n![image](/attachments/f8559840-3aa7-4b14-9e20-0dfea18965ae)\r\n\r\nThis PR adds a ton of rules to the sanitizer, which isn't ideal, but theres (currently) no other way of adding a post processing step to the markup without it going through the sanitizer.",
  "reviewers": [
    "Mai-Lapyst",
    "earl-warren"
  ],
  "assignees": [],
  "labels": [],
  "comments": []
}
[INFO ] Process succeeded
```
- Dry run test with GitLab:
```
$ node dist/cli/index.js -tb ubports/focal -pr https://gitlab.com/ubports/development/core/ubuntu-touch-session/-/merge_requests/49 --dry-run --no-s
quash
[WARN ] Dry run enabled
[INFO ] Auth argument not provided, checking available tokens from env..
[INFO ] Git token not found in the environment
[DEBUG] Setting up gitlab client: apiUrl=https://gitlab.com/api/v4, token=****
[DEBUG] Parsing configs..
[DEBUG] [ubports/focal] Cloning repo..
[INFO ] [ubports/focal] Cloning repository https://gitlab.com/ubports/development/core/ubuntu-touch-session.git to /workspaces/git-backporting/bp
[DEBUG] [ubports/focal] Creating local branch..
[INFO ] [ubports/focal] Creating branch bp-ubports/focal-4e983ad-3a9fe8b-8d2dc61
[DEBUG] [ubports/focal] Cherry picking commits..
[INFO ] [ubports/focal] Cherry picking 4e983ad01175ad1925d00154891fdaddc4c1fa16
[DEBUG] [ubports/focal] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,4e983ad01175ad1925d00154891fdaddc4c1fa16
[INFO ] [ubports/focal] Cherry picking 3a9fe8b162cc6a13021d29d61d723fa51841e30e
[DEBUG] [ubports/focal] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,3a9fe8b162cc6a13021d29d61d723fa51841e30e
[INFO ] [ubports/focal] Cherry picking 8d2dc61317c9e145e548b1651ea1b19500c06192
[DEBUG] [ubports/focal] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,8d2dc61317c9e145e548b1651ea1b19500c06192
[WARN ] [ubports/focal] Pull request creation and remote push skipped
[INFO ] [ubports/focal] {
  "owner": "ubports/development/core",
  "repo": "ubuntu-touch-session",
  "head": "bp-ubports/focal-4e983ad-3a9fe8b-8d2dc61",
  "base": "ubports/focal",
  "title": "[ubports/focal] audiosystem-passthrough-qti: switch to script for startup",
  "body": "**Backport:** https://gitlab.com/ubports/development/core/ubuntu-touch-session/-/merge_requests/49\r\n\r\nparse all manifests to accurately determine when to start\n\nSigned-off-by: Muhammad <thevancedgamer@mentallysanemainliners.org>",
  "reviewers": [
    "muhammad23012009",
    "peat-psuwit"
  ],
  "assignees": [],
  "labels": [],
  "comments": []
}
[INFO ] Process succeeded
```

### Checklist
- [x] Tests added if applicable.
- [ ] Documentation updated if applicable.

### Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits and have meaningful messages; the author will squash them _after approval_ or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

> **Note:** `dist/cli/index.js` and `dist/gha/index.js` are automatically generated by git hooks and gh workflows.

<details>
<summary>
First time here?
</summary>

This project follows [git conventional commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) pattern, therefore the commits should have the following format:

```
<type>(<optional scope>): <subject>
empty separator line
<optional body>
empty separator line
<optional footer>
```

Where the type must be one of `[build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]`

> **NOTE**: if you are still in a `work in progress` branch and you want to push your changes remotely, consider adding `--no-verify` for both `commit` and `push`, e.g., `git push origin <feat-branch> --no-verify` - this could become useful to push changes where there are still tests failures. Once the pull request is ready, please `amend` the commit and force-push it to keep following the adopted git commit standard. 

</details>

<details>
<summary>
How to prepare for a new release?
</summary>

There is no need to manually update `package.json` version and `CHANGELOG.md` information. This process has been automated in [Prepare Release](./workflows/prepare-release.yml) *Github* workflow.

Therefore whenever enough changes are merged into the `main` branch, one of the maintainers will trigger this workflow that will automatically update `version` and `changelog` based on the commits on the git tree.

More details can be found in [package release](https://github.com/kiegroup/git-backporting/blob/main/README.md#package-release) section of the README.
</details>