### PR TITLE
fix: abort conflicting cherry-pick before starting new one

### DIFF
--- a/dist/gha/index.js
+++ b/dist/gha/index.js
@@ -506,6 +506,13 @@ class GitCLIService {
             return;
         }
         this.logger.info(`Folder ${to} already exist. Won't clone`);
+        // ensure the working tree is properly reset - no stale changes 
+        // from previous (failed) backport
+        const ongoingCherryPick = await this.anyConflict(to);
+        if (ongoingCherryPick) {
+            this.logger.warn("Found previously failed cherry-pick, aborting it");
+            await this.git(to).raw(["cherry-pick", "--abort"]);
+        }
         // checkout to the proper branch
         this.logger.info(`Checking out branch ${branch}`);
         await this.git(to).checkout(branch);
@@ -562,6 +569,20 @@ class GitCLIService {
             }
             throw error;
         }
+    }
+    /**
+     * Check whether there are some conflicts in the current working directory
+     * which means there is an ongoing cherry-pick that did not complete successfully
+     * @param cwd repository in which the check should be performed
+     * @return true if there is some conflict, false otherwise
+     */
+    async anyConflict(cwd) {
+        const status = await this.git(cwd).status();
+        if (status.conflicted.length > 0) {
+            this.logger.debug(`Found conflicts in branch ${status.current}`);
+            return true;
+        }
+        return false;
     }
     /**
      * Push a branch to a remote

--- a/src/service/git/git-cli.ts
+++ b/src/service/git/git-cli.ts
@@ -68,6 +68,15 @@ export default class GitCLIService {
     }
     
     this.logger.info(`Folder ${to} already exist. Won't clone`);
+    
+    // ensure the working tree is properly reset - no stale changes 
+    // from previous (failed) backport
+    const ongoingCherryPick = await this.anyConflict(to);
+    if (ongoingCherryPick) {
+      this.logger.warn("Found previously failed cherry-pick, aborting it");
+      await this.git(to).raw(["cherry-pick", "--abort"]);
+    }
+
     // checkout to the proper branch
     this.logger.info(`Checking out branch ${branch}`);
     await this.git(to).checkout(branch);
@@ -129,6 +138,21 @@ export default class GitCLIService {
 
       throw error;
     }
+  }
+
+  /**
+   * Check whether there are some conflicts in the current working directory
+   * which means there is an ongoing cherry-pick that did not complete successfully
+   * @param cwd repository in which the check should be performed
+   * @return true if there is some conflict, false otherwise
+   */
+  async anyConflict(cwd: string): Promise<boolean> {
+    const status = await this.git(cwd).status();
+    if (status.conflicted.length > 0) {
+      this.logger.debug(`Found conflicts in branch ${status.current}`);
+      return true;
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
**Thank you for submitting this pull request**

fixes https://github.com/kiegroup/git-backporting/issues/144

## Description

When the process should backport the same change to multiple target branches, before checking out the _next_ target branch:
1. Checks whether the current _local_ repository contains any conflict
2. If yes, it means a previous cherry-pick failed, therefore it aborts the cherry-pick with `cherry-pick --abort`
3. Checkout the new  target branch

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested running:

```bash
node dist/cli/index.js -pr https://github.com/lampajr/backporting-example/pull/63 --no-squash -tb "prod,develop" -d -f /tmp/bp --strategy "ort" --strategy-option "find-renames"
```

The `develop` backport should work, the `prod` one shouldn't, here the output:

```bash
[WARN ] Trying to backport an open pull request
[DEBUG] [prod] Cloning repo..
[INFO ] [prod] Cloning repository https://github.com/lampajr/backporting-example.git to /tmp/bp
[DEBUG] [prod] Creating local branch..
[INFO ] [prod] Creating branch bp-prod-0404fb9-11da4e3
[DEBUG] [prod] Fetching pull request remote..
[INFO ] [prod] Fetching origin pull/63/head:pr/63
[DEBUG] [prod] Cherry picking commits..
[INFO ] [prod] Cherry picking 0404fb922ab75c3a8aecad5c97d9af388df04695
[DEBUG] [prod] Cherry picking command git cherry-pick,-m,1,--strategy=ort,--strategy-option=find-renames,0404fb922ab75c3a8aecad5c97d9af388df04695
[INFO ] [prod] Cherry picking 11da4e38aa3e577ffde6d546f1c52e53b04d3151
[DEBUG] [prod] Cherry picking command git cherry-pick,-m,1,--strategy=ort,--strategy-option=find-renames,11da4e38aa3e577ffde6d546f1c52e53b04d3151
[ERROR] [prod] Something went wrong backporting to prod: Error: Error: Auto-merging file2.txt
CONFLICT (content): Merge conflict in file2.txt
error: could not apply 11da4e3... Update file2.txt
hint: After resolving the conflicts, mark them with
hint: "git add/rm <pathspec>", then run
hint: "git cherry-pick --continue".
hint: You can instead skip this commit with "git cherry-pick --skip".
hint: To abort and get back to the state before "git cherry-pick",
hint: run "git cherry-pick --abort".
hint: Disable this message with "git config advice.mergeConflict false"

Showing git diff:
diff --cc file2.txt
index 93e9c13,bf04643..0000000
--- a/file2.txt
+++ b/file2.txt
@@@ -2,5 -2,4 +2,9 @@@ feature2: update
  test2: updated
  feature2: updated x 2
  feature1: updated
++<<<<<<< HEAD
 +force conflict
 +force conflict x2
++=======
+ multiple commit change
++>>>>>>> 11da4e3 (Update file2.txt)

[DEBUG] [develop] Cloning repo..
[INFO ] [develop] Cloning repository https://github.com/lampajr/backporting-example.git to /tmp/bp
[INFO ] [develop] Folder /tmp/bp already exist. Won't clone
[DEBUG] [develop] Found conflicts in branch bp-prod-0404fb9-11da4e3
[WARN ] [develop] Found previously failed cherry-pick, aborting it
[INFO ] [develop] Checking out branch develop
[DEBUG] [develop] Creating local branch..
[INFO ] [develop] Creating branch bp-develop-0404fb9-11da4e3
[DEBUG] [develop] Fetching pull request remote..
[INFO ] [develop] Fetching origin pull/63/head:pr/63
[DEBUG] [develop] Cherry picking commits..
[INFO ] [develop] Cherry picking 0404fb922ab75c3a8aecad5c97d9af388df04695
[DEBUG] [develop] Cherry picking command git cherry-pick,-m,1,--strategy=ort,--strategy-option=find-renames,0404fb922ab75c3a8aecad5c97d9af388df04695
[INFO ] [develop] Cherry picking 11da4e38aa3e577ffde6d546f1c52e53b04d3151
[DEBUG] [develop] Cherry picking command git cherry-pick,-m,1,--strategy=ort,--strategy-option=find-renames,11da4e38aa3e577ffde6d546f1c52e53b04d3151
[WARN ] [develop] Pull request creation and remote push skipped
[INFO ] [develop] {
  "owner": "lampajr",
  "repo": "backporting-example",
  "head": "bp-develop-0404fb9-11da4e3",
  "base": "develop",
  "title": "[develop] Update file1.txt",
  "body": "**Backport:** https://github.com/lampajr/backporting-example/pull/63\r\n\r\nThis PR aims to reset a file",
  "reviewers": [
    "lampajr"
  ],
  "assignees": [],
  "labels": [],
  "comments": []
}
```

As you can see, the first one (against `prod`) failed but the second one (against `develop`) succeeded as expected.

### Checklist
- [ ] Tests added if applicable.
- [ ] Documentation updated if applicable.

### Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them _after approval_ or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

> **Note:** `dist/cli/index.js` and `dist/gha/index.js` are automatically generated by git hooks and gh workflows.

<details>
<summary>
First time here?
</summary>

This project follows [git conventional commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) pattern, therefore the commits should have the following format:

```
<type>(<optional scope>): <subject>
empty separator line
<optional body>
empty separator line
<optional footer>
```

Where the type must be one of `[build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]`

> **NOTE**: if you are still in a `work in progress` branch and you want to push your changes remotely, consider adding `--no-verify` for both `commit` and `push`, e.g., `git push origin <feat-branch> --no-verify` - this could become useful to push changes where there are still tests failures. Once the pull request is ready, please `amend` the commit and force-push it to keep following the adopted git commit standard. 

</details>

<details>
<summary>
How to prepare for a new release?
</summary>

There is no need to manually update `package.json` version and `CHANGELOG.md` information. This process has been automated in [Prepare Release](./workflows/prepare-release.yml) *Github* workflow.

Therefore whenever enough changes are merged into the `main` branch, one of the maintainers will trigger this workflow that will automatically update `version` and `changelog` based on the commits on the git tree.

More details can be found in [package release](https://github.com/kiegroup/git-backporting/blob/main/README.md#package-release) section of the README.
</details>