### PR TITLE
fix: don't backport if branch already exists

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -641,6 +641,16 @@ class GitCLIService {
         await this.git(cwd).fetch(remote, branch, ["--quiet"]);
     }
     /**
+     * Check if a branch exists in a remote repository.
+     * @param remote remote name or URL
+     * @param branch branch name to search
+     */
+    async remoteBranchExists(remote, branch) {
+        this.logger.info(`Checking if branch ${branch} exists on ${remote}`);
+        const output = await (0, simple_git_1.default)().raw(["ls-remote", "--heads", this.remoteWithAuth(remote), branch]);
+        return output.trim().length > 0;
+    }
+    /**
      * Get cherry-pick a specific sha
      * @param cwd repository in which the sha should be cherry picked to
      * @param sha commit sha
@@ -1752,6 +1762,12 @@ class Runner {
         return token;
     }
     async executeBackport(configs, backportPR, git) {
+        const remote = backportPR.headRepo?.cloneUrl ?? backportPR.cloneUrl;
+        const branchExists = await git.gitCli.remoteBranchExists(remote, backportPR.head);
+        if (branchExists) {
+            this.logger.warn(`Backport branch ${backportPR.head} already exists on ${remote}, skipping`);
+            return;
+        }
         let i = 0;
         for (const step of backportSteps(this.logger, configs, backportPR, git)) {
             try {
@@ -1876,6 +1892,9 @@ async function backportScript(configs, backportPR, git, failed) {
         },
         async fetch(_cwd, branch, remote = "origin") {
             s += `git fetch ${remote} ${branch}`;
+        },
+        async remoteBranchExists(_remote, _branch) {
+            return false;
         },
         async cherryPick(_cwd, sha, strategy = "recursive", strategyOption = "theirs", cherryPickOptions) {
             s += `git cherry-pick -m 1 --strategy=${strategy} --strategy-option=${strategyOption} `;

--- a/dist/gha/index.js
+++ b/dist/gha/index.js
@@ -604,6 +604,16 @@ class GitCLIService {
         await this.git(cwd).fetch(remote, branch, ["--quiet"]);
     }
     /**
+     * Check if a branch exists in a remote repository.
+     * @param remote remote name or URL
+     * @param branch branch name to search
+     */
+    async remoteBranchExists(remote, branch) {
+        this.logger.info(`Checking if branch ${branch} exists on ${remote}`);
+        const output = await (0, simple_git_1.default)().raw(["ls-remote", "--heads", this.remoteWithAuth(remote), branch]);
+        return output.trim().length > 0;
+    }
+    /**
      * Get cherry-pick a specific sha
      * @param cwd repository in which the sha should be cherry picked to
      * @param sha commit sha
@@ -1715,6 +1725,12 @@ class Runner {
         return token;
     }
     async executeBackport(configs, backportPR, git) {
+        const remote = backportPR.headRepo?.cloneUrl ?? backportPR.cloneUrl;
+        const branchExists = await git.gitCli.remoteBranchExists(remote, backportPR.head);
+        if (branchExists) {
+            this.logger.warn(`Backport branch ${backportPR.head} already exists on ${remote}, skipping`);
+            return;
+        }
         let i = 0;
         for (const step of backportSteps(this.logger, configs, backportPR, git)) {
             try {
@@ -1839,6 +1855,9 @@ async function backportScript(configs, backportPR, git, failed) {
         },
         async fetch(_cwd, branch, remote = "origin") {
             s += `git fetch ${remote} ${branch}`;
+        },
+        async remoteBranchExists(_remote, _branch) {
+            return false;
         },
         async cherryPick(_cwd, sha, strategy = "recursive", strategyOption = "theirs", cherryPickOptions) {
             s += `git cherry-pick -m 1 --strategy=${strategy} --strategy-option=${strategyOption} `;

--- a/src/service/git/git-cli.ts
+++ b/src/service/git/git-cli.ts
@@ -123,6 +123,17 @@ export default class GitCLIService {
   }
 
   /**
+   * Check if a branch exists in a remote repository.
+   * @param remote remote name or URL
+   * @param branch branch name to search
+   */
+  async remoteBranchExists(remote: string, branch: string): Promise<boolean> {
+    this.logger.info(`Checking if branch ${branch} exists on ${remote}`);
+    const output = await simpleGit().raw(["ls-remote", "--heads", this.remoteWithAuth(remote), branch]);
+    return output.trim().length > 0;
+  }
+
+  /**
    * Get cherry-pick a specific sha
    * @param cwd repository in which the sha should be cherry picked to
    * @param sha commit sha

--- a/src/service/runner/runner.ts
+++ b/src/service/runner/runner.ts
@@ -14,7 +14,7 @@ import { injectError, injectTargetBranch } from "./runner-util";
 interface Git {
   gitClientType: GitClientType;
   gitClientApi: Pick<GitClient, ("createPullRequest" | "createPullRequestComment")>;
-  gitCli: Pick<GitCLIService, ("clone" | "createLocalBranch" | "fetch" | "cherryPick" | "addRemote" | "push")>;
+  gitCli: Pick<GitCLIService, ("clone" | "createLocalBranch" | "fetch" | "remoteBranchExists" | "cherryPick" | "addRemote" | "push")>;
 }
 
 /**
@@ -125,6 +125,13 @@ export default class Runner {
   }
 
   async executeBackport(configs: Configs, backportPR: BackportPullRequest, git: Git): Promise<void> {
+    const remote = backportPR.headRepo?.cloneUrl ?? backportPR.cloneUrl;
+    const branchExists = await git.gitCli.remoteBranchExists(remote, backportPR.head);
+    if (branchExists) {
+      this.logger.warn(`Backport branch ${backportPR.head} already exists on ${remote}, skipping`);
+      return;
+    }
+
     let i = 0;
     for (const step of backportSteps(this.logger, configs, backportPR, git)) {
       try {
@@ -258,6 +265,9 @@ async function backportScript(configs: Configs, backportPR: BackportPullRequest,
     },
     async fetch(_cwd: string, branch: string, remote = "origin"): Promise<void> {
       s += `git fetch ${remote} ${branch}`;
+    },
+    async remoteBranchExists(_remote: string, _branch: string): Promise<boolean> {
+      return false;
     },
     async cherryPick(_cwd: string, sha: string, strategy = "recursive", strategyOption = "theirs", cherryPickOptions: string | undefined): Promise<void> {
       s += `git cherry-pick -m 1 --strategy=${strategy} --strategy-option=${strategyOption} `;


### PR DESCRIPTION
## Description
Right now, any label changes will cause the action to re-run and try to open a ton of duplicate PRs.

## How Has This Been Tested?
This has been in use on FFmpeg Forgejo via https://code.ffmpeg.org/actions/git-backporting since a while now, and it's working great.
I had to slightly modify it due to changes here, but that seemed super minimal to me: It had to use `backportPR.cloneUrl` now.

### Checklist
- [ ] Tests added if applicable.
- [ ] Documentation updated if applicable.